### PR TITLE
Show a message when data is loading in related orgs tab

### DIFF
--- a/app/controllers/organizations/organization/related-organizations.js
+++ b/app/controllers/organizations/organization/related-organizations.js
@@ -7,4 +7,14 @@ export default class OrganizationsOrganizationRelatedOrganizationsController ext
   @tracked sort = 'name';
   @tracked page = 0;
   @tracked size = 25;
+
+  get subOrganizations() {
+    return this.model.loadSubOrganizationsTaskInstance.isFinished
+      ? this.model.loadSubOrganizationsTaskInstance.value
+      : this.model.subOrganizations;
+  }
+
+  get isLoading() {
+    return this.model.loadSubOrganizationsTaskInstance.isRunning;
+  }
 }

--- a/app/routes/organizations/organization/related-organizations.js
+++ b/app/routes/organizations/organization/related-organizations.js
@@ -12,14 +12,13 @@ export default class OrganizationsOrganizationRelatedOrganizationsRoute extends 
 
   async model(params) {
     const organization = this.modelFor('organizations.organization');
-
-    const subOrganizations = await this.loadSubOrganizationsTask.perform(
-      organization.id,
-      params
-    );
     return {
+      loadSubOrganizationsTaskInstance: this.loadSubOrganizationsTask.perform(
+        organization.id,
+        params
+      ),
       organization,
-      subOrganizations,
+      subOrganizations: this.loadSubOrganizationsTask.lastSuccessful?.value,
     };
   }
 

--- a/app/templates/organizations/organization/related-organizations.hbs
+++ b/app/templates/organizations/organization/related-organizations.hbs
@@ -12,9 +12,10 @@
     <:subtitle>{{@model.organization.name}}</:subtitle>
   </PageHeader>
 
-  {{#if @model.subOrganizations.length}}
+  {{#if this.subOrganizations.length}}
       <AuDataTable id="subOrganizations"
-        @content={{this.model.subOrganizations}}
+        @content={{this.subOrganizations}}
+        @isLoading={{this.isLoading}}
         @sort={{this.sort}}
         @page={{this.page}}
         @size={{this.size}}


### PR DESCRIPTION
The branch name is misleading sorry, goal was to add a loading state in the related organization tabs (ex. Bisdom Gent) and it has the form of a message, not dancing dots.

Solves OP-1271