### PR TITLE
fix contact details copy with invalid existing data

### DIFF
--- a/app/components/contact-details.hbs
+++ b/app/components/contact-details.hbs
@@ -77,7 +77,7 @@
 
             <td>
 
-              <AuButton @skin="link" {{on "click" (fn this.copy contact)}}>
+              <AuButton @skin="link" {{on "click" (perform this.copy contact)}}>
                 <AuControlCheckbox
                   @label=""
                   @checked={{(eq


### PR DESCRIPTION
see OP-1364.

to reproduce:
- check for a position with invalid contact details
- example: http://localhost:4200/bestuurseenheden/4c03829486377310ada8bf402bb591be/bestuursorganen/513431c6618f670fc069b3512f789799/mandataris/4f03f3797a22d2a7c4e9580474a069cf
- try to select one (copy it)
- it should now open the popup and force you to edit it before being able to select it