### PR TITLE
Fix typo in page header title

### DIFF
--- a/app/templates/people/person/personal-information/request-sensitive-data.hbs
+++ b/app/templates/people/person/personal-information/request-sensitive-data.hbs
@@ -1,7 +1,7 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
-      <:title>Consulteer personlijke gegevens</:title>
+      <:title>Consulteer persoonlijke gegevens</:title>
       <:subtitle>
         {{@model.person.givenName}}
         {{@model.person.familyName}}


### PR DESCRIPTION
As discovered in the chat during CPD20