### PR TITLE
Add error message and log error when no target person in position

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.js
+++ b/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.js
@@ -16,6 +16,7 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @tracked positionId;
 
   @tracked targetPerson = null;
+  @tracked targetPersonError = false;
 
   get isSelectingTargetPerson() {
     return !this.targetPerson;
@@ -71,7 +72,21 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       address.validate(),
     ]);
 
-    if (
+    if (!this.targetPerson) {
+      this.targetPersonError = true;
+
+      const now = new Date().toISOString();
+      const error = this.store.createRecord('job-error', {
+        subject: 'Frontend - Unexpected error',
+        message:
+          'Unexpected error when trying to save a position : no target person linked',
+        detail: `Error when trying to save position belonging to governing body ${governingBody.id} for role ${mandatory.role.id}`,
+        created: now,
+        creator: 'http://lblod.data.gift/services/organization-portal-frontend',
+      });
+
+      error.save();
+    } else if (
       mandatory.isValid &&
       contact.isValid &&
       secondaryContact.isValid &&

--- a/app/models/job-error.js
+++ b/app/models/job-error.js
@@ -1,0 +1,10 @@
+import Model, { attr } from '@ember-data/model';
+
+export default class JobErrorModel extends Model {
+  @attr subject;
+  @attr message;
+  @attr detail;
+  @attr references;
+  @attr created;
+  @attr creator;
+}

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.hbs
@@ -41,6 +41,13 @@
       aria-label="minister-position-creation-form"
       {{on "submit" (perform this.createMandatoryPositionTask)}}
     >
+
+    {{#if this.targetPersonError}}
+      <AuAlert @alertIcon="alert-triangle" @alertTitle="Er is een onverwachte fout opgetreden." @alertSkin="error">
+        <p>Probeer de persoon opnieuw aan de positie toe te voegen. Als het niet lukt, neem dan contact met ons op.</p>
+      </AuAlert>
+    {{/if}}
+
       <DataCard>
         <:title>Persoonlijke gegevens</:title>
         <:card as |Card|>


### PR DESCRIPTION
Improvements for OP-1359

Needs to be tested with https://github.com/lblod/app-organization-portal/tree/hotfix/v1.7.8

As we can't reproduce it, to test if, modify `if (!this.targetPerson)` to `if (this.targetPerson)`.

This query shows the saved errors :
```
PREFIX dct: <http://purl.org/dc/terms/>

SELECT *
WHERE {
  ?s a <http://open-services.net/ns/core#Error> ;
    dct:creator <http://lblod.data.gift/services/organization-portal-frontend> ;
    ?p ?o .
}
```