### PR TITLE
fix weird behavior with aulink

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/edit.js
@@ -7,7 +7,7 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @service router;
 
   @action
-  reset() {
+  cancel() {
     this.model.governingBody.rollbackAttributes();
     this.router.transitionTo(
       'administrative-units.administrative-unit.governing-bodies.governing-body'

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
@@ -18,12 +18,12 @@
               Opslaan
             </AuButton>
 
-            <AuLink
-              {{on "click" this.reset}}
-              @skin="button-secondary"
+            <AuButton
+              {{on "click" this.cancel}}
+              @skin="secondary"
             >
               Annuleer
-            </AuLink>
+            </AuButton>
           </AuButtonGroup>
           <ReportWrongData />
         </div>


### PR DESCRIPTION
seems fixing OP-1352's comment of kevin:

    When you press ‘Annuleer’ when no edits were made > you’re brought back to the previous page. (OK) :check_mark:

    When you press ‘Annuleer’ when edits were made > undoes the edits (OK) :check_mark: but doesn’t bring the user back to the previous page (even with repeated clicking the button) (NOK) :minus: