### PR TITLE
message announcement

### DIFF
--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -2,12 +2,25 @@
 
 <AppHeader />
 
+{{#if (eq "true" (config "announce.maintenance.enabled"))}}
+  <AuAlert @skin="warning"  @icon="alert-triangle" class="au-u-margin-bottom-none">
+    <p>{{config "announce.maintenance.message"}}</p>
+  </AuAlert>
+{{else if (eq "true" (config "announce.newDeployment.enabled"))}}
+  <AuAlert @skin="warning" @icon="alert-triangle"  class="au-u-margin-bottom-none">
+    <p>{{config "announce.newDeployment.message"}}</p>
+  </AuAlert>
+{{else if (eq "true" (config "announce.testing.enabled"))}}
+  <AuAlert @skin="warning" @icon="alert-triangle"  class="au-u-margin-bottom-none">
+    <p>{{config "announce.testing.message"}}</p>
+  </AuAlert>
+
+{{/if}}
+
 <main id="main" class="au-c-main-container">
-  <div
-    class="au-c-main-container__content"
-    id="content"
-    tabindex="-1"
-  >
+
+  <div class="au-c-main-container__content" id="content" tabindex="-1">
+
     {{outlet}}
   </div>
 </main>

--- a/config/environment.js
+++ b/config/environment.js
@@ -29,19 +29,16 @@ module.exports = function (environment) {
 
     announce: {
       maintenance: {
-        enabled: 'true',
-        message:
-          '(f.e. Het OrganisatiePortaal zal donderdag 24/03 tussen 12:00 en 15.00 u. onbeschikbaar zijn wegens onderhoud)',
+        enabled: '{{ANNOUNCE_MAINTENANCE_ENABLED}}',
+        message: '{{ANNOUNCE_MAINTENANCE_MESSAGE}}',
       },
       newDeployment: {
         enabled: '{{ANNOUNCE_NEW_DEPLOYMENT_ENABLED}}',
-        message:
-          '(f.e. Het OrganisatiePortaal zal vanaf donderdag 24/03, 19.00 uur t.e.m. vrijdag 25/03 8.00 uur onbeschikbaar zijn wegens de uitrol van een nieuwe versie)',
+        message: '{{ANNOUNCE_NEW_DEPLOYMENT_MESSAGE}}',
       },
       testing: {
         enabled: '{{ANNOUNCE_TESTING_ENABLED}}',
-        message:
-          '(f.e. Het OrganisatiePortaal zal vandaag, donderdag 24/03, niet stabiel zijn wegens uitvoering van testen.)',
+        message: '{{ANNOUNCE_TESTING_MESSAGE}}',
       },
     },
     appName: 'OrganisatiePortaal',

--- a/config/environment.js
+++ b/config/environment.js
@@ -27,6 +27,23 @@ module.exports = function (environment) {
       },
     },
 
+    announce: {
+      maintenance: {
+        enabled: 'true',
+        message:
+          '(f.e. Het OrganisatiePortaal zal donderdag 24/03 tussen 12:00 en 15.00 u. onbeschikbaar zijn wegens onderhoud)',
+      },
+      newDeployment: {
+        enabled: '{{ANNOUNCE_NEW_DEPLOYMENT_ENABLED}}',
+        message:
+          '(f.e. Het OrganisatiePortaal zal vanaf donderdag 24/03, 19.00 uur t.e.m. vrijdag 25/03 8.00 uur onbeschikbaar zijn wegens de uitrol van een nieuwe versie)',
+      },
+      testing: {
+        enabled: '{{ANNOUNCE_TESTING_ENABLED}}',
+        message:
+          '(f.e. Het OrganisatiePortaal zal vandaag, donderdag 24/03, niet stabiel zijn wegens uitvoering van testen.)',
+      },
+    },
     appName: 'OrganisatiePortaal',
     contactEmail: 'organisaties.abb@vlaanderen.be',
     environmentName: '{{ENVIRONMENT_NAME}}', // Supported values: LOCAL, DEV, QA


### PR DESCRIPTION
OP-1430

to test:
- Build locally the frontend
- add env variable ::
```
# to show the maintenance message
     EMBER_ANNOUNCE_MAINTENANCE_ENABLED: "true" 
     EMBER_ANNOUNCE_MAINTENANCE_MESSAGE: "(f.e. Het OrganisatiePortaal zal donderdag 24/03 tussen 12:00 en 15.00 u. onbeschikbaar zijn wegens onderhoud)"
```

```
# to show the new deployment message
     EMBER_ANNOUNCE_NEW_DEPLOYMENT_ENABLED:  "true"
     EMBER_ANNOUNCE_NEW_DEPLOYMENT_MESSAGE:  "(f.e. Het OrganisatiePortaal zal vanaf donderdag 24/03, 19.00 uur t.e.m. vrijdag 25/03 8.00 uur onbeschikbaar zijn wegens de uitrol van een nieuwe versie)" 
```
```
#to show the testing message
     EMBER_ANNOUNCE_TESTING_ENABLED: "true"
     EMBER_ANNOUNCE_TESTING_MESSAGE: "(f.e. Het OrganisatiePortaal zal vandaag, donderdag 24/03, niet stabiel zijn wegens uitvoering van testen.)"
```
![image](https://user-images.githubusercontent.com/3816305/174990263-98be8636-2956-4822-89a1-01b8143a27ad.png)

