### PR TITLE
Fix references to region vs municipatily

### DIFF
--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -313,6 +313,6 @@ function copyAdministrativeUnitData(newAdministrativeUnit, administrativeUnit) {
       administrativeUnit.subOrganizations;
   }
   newAdministrativeUnit.isAssociatedWith = administrativeUnit.isAssociatedWith;
-  newAdministrativeUnit.locatedWithin = administrativeUnit.locatedWithin;
-  newAdministrativeUnit.scope = administrativeUnit.scope;
+  newAdministrativeUnit.scope.locatedWithin =
+    administrativeUnit.scope.locatedWithin;
 }

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -21,10 +21,14 @@ export default class AdministrativeUnitModel extends OrganizationModel {
     inverse: 'administrativeUnit',
   })
   involvedBoards;
+
   @belongsTo('concept', {
     inverse: null,
   })
   exactMatch;
-  @belongsTo('location', { inverse: null })
+
+  @belongsTo('location', {
+    inverse: null,
+  })
   scope;
 }

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -143,9 +143,9 @@
                     <:label>Regio</:label>
                     <:content>
                       <RegionSelect
-                        @selected={{@model.administrativeUnit.scope}}
+                        @selected={{@model.administrativeUnit.scope.locatedWithin}}
                         @onChange={{fn
-                          (mut @model.administrativeUnit.scope)
+                          (mut @model.administrativeUnit.scope.locatedWithin)
                         }}
                         @id="regio"
                       />

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -2,7 +2,8 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Kerngegevens</:title>
-      <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.name}}
+        ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <SecuredArea>
           <:edit>
@@ -77,11 +78,11 @@
                 </:content>
               </Item>
             {{/if}}
-            {{#if @model.administrativeUnit.scope}}
+            {{#if @model.administrativeUnit.scope.locatedWithin}}
               <Item>
                 <:label>Regio</:label>
                 <:content>
-                  {{@model.administrativeUnit.scope.label}}
+                  {{@model.administrativeUnit.scope.locatedWithin.label}}
                 </:content>
               </Item>
             {{/if}}

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -138,9 +138,9 @@
                 <:label>Regio</:label>
                 <:content>
                   <RegionSelect
-                    @selected={{@model.administrativeUnitChangeset.scope}}
+                    @selected={{@model.administrativeUnitChangeset.scope.locatedWithin}}
                     @onChange={{fn
-                      (mut @model.administrativeUnitChangeset.scope)
+                      (mut @model.administrativeUnitChangeset.scope.locatedWithin)
                     }}
                     @id="regio"
                   />


### PR DESCRIPTION
Refer to the region instead of the municipality working area.
The municipality working area is located within the region.

Note that the first iteration uses an implicit reference to the higher level, a possible improvement is to check whether that higher level is a `Referentieregio`. 