### PR TITLE
Hotfix revert banner - showing on prod

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -192,18 +192,7 @@ $ember-power-select-focus-outline: solid 2px rgb(16, 108, 200) !default;
   vertical-align: top !important;
 }
 
-header {
-  &.au-c-main-header {
-    z-index: 3;
-  }
-}
-
 .au-c-body-container {
-  &.au-c-body-container--scroll {
-    .au-c-button-group {
-      flex-direction: row-reverse;
-    }
-  }
   header {
     .au-c-toolbar {
       .au-c-toolbar__group {
@@ -212,11 +201,5 @@ header {
         }
       }
     }
-  }
-}
-
-.au-c-card-item__label {
-  &.au-c-card-item__label--edit {
-    align-self: baseline;
   }
 }

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -92,7 +92,6 @@
 @import "components/cards";
 @import "components/sidebar-container";
 @import "components/table-message";
-@import "components/environment-banner";
 
 // PLUGINS
 @import "ember-appuniversum/p-ember-power-select";

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -5,14 +5,6 @@
 }}
 <AuApp class='{{(if this.showEnvironment (concat 'au-c-app--environment au-c-environment--' this.environmentName))}}'>
 
-  {{#if this.showEnvironment}}
-    <Environment::Banner
-      @environmentName={{this.environmentName}}
-      @environmentTitle={{this.environmentTitle}}
-      @applicationName='Organisatie Portaal'
-    />
-  {{/if}}
-
   <AppHeader />
 
   {{#if (eq "true" (config "announce.maintenance.enabled"))}}
@@ -31,8 +23,6 @@
   {{/if}}
 
   <main id="main" class="au-c-main-container">
-
-
 
     <div class="au-c-main-container__content" id="content" tabindex="-1">
       {{outlet}}


### PR DESCRIPTION
FYI @iurianu 

![Capture d’écran du 2022-11-25 18-03-20](https://user-images.githubusercontent.com/23281659/204031772-5ec993b9-e4f5-4d4c-b1f3-9101971a89b8.png)

It will have to be fixed to
1. not show the banner on prod
2. not have a gap in the top of the page when no banner is shown
3. fix the {{ENVIRONMENT_TITLE}} value on QA