### PR TITLE
Disable position creation or edition from 01/02/2023

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
+++ b/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/index.js
@@ -26,4 +26,8 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
       CLASSIFICATION_CODE.CENTRAL_WORSHIP_SERVICE
     );
   }
+
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
 }

--- a/app/controllers/administrative-units/administrative-unit/ministers/index.js
+++ b/app/controllers/administrative-units/administrative-unit/ministers/index.js
@@ -7,4 +7,8 @@ export default class AdministrativeUnitsAdministrativeUnitMinistersIndexControll
   get currentURL() {
     return this.router.currentURL;
   }
+
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
 }

--- a/app/controllers/people/new-position.js
+++ b/app/controllers/people/new-position.js
@@ -24,6 +24,10 @@ export default class PeopleNewPositionController extends Controller {
 
   @tracked positionTypes = [MANDATE, MINISTER];
 
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
+
   @action
   async setOrganization(organization) {
     this.governingBodyClassifications = null;

--- a/app/controllers/people/person/personal-information/index.js
+++ b/app/controllers/people/person/personal-information/index.js
@@ -12,4 +12,8 @@ export default class PeoplePersonPersonalInformationIndexController extends Cont
       .map((n) => n.nationalityLabel)
       .join(', ');
   }
+
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
 }

--- a/app/controllers/people/person/positions/mandatory/index.js
+++ b/app/controllers/people/person/positions/mandatory/index.js
@@ -27,4 +27,8 @@ export default class MandatoryIndexController extends Controller {
         .get('id') === CLASSIFICATION_CODE.CENTRAL_WORSHIP_SERVICE
     );
   }
+
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
 }

--- a/app/controllers/people/person/positions/minister/index.js
+++ b/app/controllers/people/person/positions/minister/index.js
@@ -1,0 +1,7 @@
+import Controller from '@ember/controller';
+
+export default class MinisterIndexController extends Controller {
+  get positionsCantBeCreatedOrEdited() {
+    return new Date() >= new Date('2023-02-01');
+  }
+}

--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/edit.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/edit.js
@@ -10,7 +10,9 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @service router;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/new.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/new.js
@@ -11,7 +11,9 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @service contactDetails;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/edit.js
@@ -10,7 +10,9 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @service router;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.js
+++ b/app/routes/administrative-units/administrative-unit/governing-bodies/governing-body/mandatory/new.js
@@ -11,7 +11,9 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
   @service contactDetails;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/administrative-units/administrative-unit/ministers/new.js
+++ b/app/routes/administrative-units/administrative-unit/ministers/new.js
@@ -12,7 +12,9 @@ export default class AdministrativeUnitsAdministrativeUnitMinistersNewRoute exte
   @service contactDetails;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/people/person/personal-information/edit.js
+++ b/app/routes/people/person/personal-information/edit.js
@@ -11,7 +11,9 @@ export default class PeoplePersonPersonalInformationEditRoute extends Route {
   @service store;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/routes/people/person/positions/minister/edit.js
+++ b/app/routes/people/person/positions/minister/edit.js
@@ -10,7 +10,9 @@ export default class PeoplePersonPositionsMinisterEditRoute extends Route {
   @service store;
 
   beforeModel() {
-    if (!this.currentSession.canEdit) {
+    // Disabling positions creation and edition, they now happen in Loket.
+    const positionsCantBeCreatedOrEdited = new Date() >= new Date('2023-02-01');
+    if (!this.currentSession.canEdit || positionsCantBeCreatedOrEdited) {
       this.router.transitionTo('route-not-found', {
         wildcard: 'pagina-niet-gevonden',
       });

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
@@ -73,7 +73,9 @@
         <AuToolbarGroup>
           <AuHeading @level="4" @skin="5">Bestuursleden</AuHeading>
         </AuToolbarGroup>
-        {{#if this.isWorshipAdministrativeUnit}}
+        {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+        editing code, we will use it for positions unavailable in Loket --}}
+        {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
           <AuToolbarGroup>
             <SecuredArea>
               <:edit>
@@ -116,7 +118,9 @@
             />
             <th class="au-c-data-table__header-title">Start mandaat</th>
             <th class="au-c-data-table__header-title">Einde mandaat</th>
-            {{#if this.isWorshipAdministrativeUnit}}
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
               <SecuredArea>
                 <:edit>
                   <th></th>
@@ -161,7 +165,9 @@
                 {{date-format mandatory.expectedEndDate}}
               {{/if}}
             </td>
-            {{#if this.isWorshipAdministrativeUnit}}
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
               <SecuredArea>
                 <:edit>
                   <td>
@@ -189,7 +195,9 @@
         <AuToolbarGroup>
           <AuHeading @level="4" @skin="5">Mandatarissen</AuHeading>
         </AuToolbarGroup>
-        {{#if this.isWorshipAdministrativeUnit}}
+        {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+        editing code, we will use it for positions unavailable in Loket --}}
+        {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
           <AuToolbarGroup>
             <SecuredArea>
               <:edit>
@@ -230,7 +238,9 @@
             />
             <th class="au-c-data-table__header-title">Start mandaat</th>
             <th class="au-c-data-table__header-title">Einde mandaat</th>
-            {{#if this.isWorshipAdministrativeUnit}}
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
               <SecuredArea>
                 <:edit>
                   <th></th>
@@ -275,7 +285,9 @@
                 {{date-format mandatory.expectedEndDate}}
               {{/if}}
             </td>
-            {{#if this.isWorshipAdministrativeUnit}}
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
               <SecuredArea>
                 <:edit>
                   <td>

--- a/app/templates/administrative-units/administrative-unit/ministers/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/index.hbs
@@ -4,14 +4,18 @@
   <:action>
     <SecuredArea>
       <:edit>
-        <AuLink
-          @route="administrative-units.administrative-unit.ministers.new"
-          @icon="add"
-          @iconAlignment="left"
-          @skin="button"
-        >
-          Nieuw
-        </AuLink>
+        {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+        editing code, we will use it for positions unavailable in Loket --}}
+        {{#unless this.positionsCantBeCreatedOrEdited}}
+          <AuLink
+            @route="administrative-units.administrative-unit.ministers.new"
+            @icon="add"
+            @iconAlignment="left"
+            @skin="button"
+          >
+            Nieuw
+          </AuLink>
+        {{/unless}}
       </:edit>
       <:readOnly>
         <ReportWrongData />
@@ -31,11 +35,15 @@
       <th class="au-c-data-table__header-title">Achternaam</th>
       <th class="au-c-data-table__header-title">Rol</th>
       <th class="au-c-data-table__header-title">Status</th>
-      <SecuredArea>
-        <:edit>
-          <th></th>
-        </:edit>
-      </SecuredArea>
+      {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+      editing code, we will use it for positions unavailable in Loket --}}
+      {{#unless this.positionsCantBeCreatedOrEdited}}
+        <SecuredArea>
+          <:edit>
+            <th></th>
+          </:edit>
+        </SecuredArea>
+      {{/unless}}
     </c.header>
     <c.body as |minister|>
         <td>
@@ -59,19 +67,23 @@
         <td>
           <PositionStatus @endDate={{minister.agentEndDate}} />
         </td>
-        <SecuredArea>
-          <:edit>
-            <td>
-              <AuLink
-                @route="people.person.positions.minister.edit"
-                @models={{array minister.person.id minister.id}}
-                @query={{hash redirectUrl=this.currentURL}}
-              >
-                Bewerk
-              </AuLink>
-            </td>
-          </:edit>
-        </SecuredArea>
+        {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+        editing code, we will use it for positions unavailable in Loket --}}
+        {{#unless this.positionsCantBeCreatedOrEdited}}
+          <SecuredArea>
+            <:edit>
+              <td>
+                <AuLink
+                  @route="people.person.positions.minister.edit"
+                  @models={{array minister.person.id minister.id}}
+                  @query={{hash redirectUrl=this.currentURL}}
+                >
+                  Bewerk
+                </AuLink>
+              </td>
+            </:edit>
+          </SecuredArea>
+        {{/unless}}
     </c.body>
   </t.content>
 </AuDataTable>

--- a/app/templates/people/index.hbs
+++ b/app/templates/people/index.hbs
@@ -75,7 +75,6 @@
                 </:edit>
               </SecuredArea>
             </:alert>
-
           </PageHeader>
           <div class="au-o-box">
             <AuToggleSwitch
@@ -112,7 +111,7 @@
         {{#if this.hasErrored}}
           <TableMessage::Error />
         {{else if this.hasNoResults}}
-         <TableMessage>
+          <TableMessage>
             <p>
               Er werden geen zoekresultaten gevonden. Kijk na op spelfouten, of
               probeer een andere zoekopdracht. Indien een persoon ontbreekt,

--- a/app/templates/people/new-position.hbs
+++ b/app/templates/people/new-position.hbs
@@ -16,133 +16,144 @@
         </AuButtonGroup>
       </:action>
     </PageHeader>
-
-    <form id="person-creation" {{on "submit" this.redirect}}>
-      <EditCard @containsRequiredFields={{true}}>
-        <:title>Selecteer</:title>
-        <:card as |Card|>
-          <Card.Columns>
-            <:left as |Item|>
-              <Item
-                @labelFor="position-type"
-                @alignTop={{true}}
-                @required={{true}}
-              >
-                <:label>Type</:label>
-                <:content>
-                  <PowerSelect
-                    @options={{this.positionTypes}}
-                    @selected={{this.positionType}}
-                    @onChange={{this.setPositionType}}
-                    @triggerId="position-type"
-                    as |positionType|
-                  >
-                    {{positionType}}
-                  </PowerSelect>
-                </:content>
-              </Item>
-            </:left>
-          </Card.Columns>
-          <Card.Columns>
-            <:left as |Item|>
-              {{#if this.positionType}}
-            <Item
-                @labelFor="organization"
-                @required={{true}}
-              >
-                <:label>Naam bestuur</:label>
-                <:content>
-                  <AdministrativeUnitSelect
-                    @classificationCodes={{this.classificationCodes}}
-                    @selected={{this.selectedOrganization}}
-                    @onChange={{this.setOrganization}}
-                    id="organization"
-                  />
-                </:content>
-              </Item>
-              {{/if}}
-
-              {{#if
-                (and
-                  (eq this.positionType "Mandaat")
-                  this.governingBodyClassifications
-                )
-              }}
-                <Item @labelFor="board-position-code" @required={{true}}>
-                  <:label>Mandaat</:label>
-                  <:content>
-                    <MandateRoleSelect
-                      @selected={{this.selectedRole}}
-                      @selectedAdministrativeUnit={{this.selectedOrganization}}
-                      @onChange={{this.setRole}}
-                      @id="board-position-code"
-                    />
-                  </:content>
-                </Item>
-              {{/if}}
-              {{#if (and this.selectedOrganization (eq this.positionType "Bedienaar"))}}
-                <Item @labelFor="minister-position-function" @required={{true}}>
-                  <:label>Rol</:label>
-                  <:content>
-                    <MinisterPositionFunctionSelect
-                      @onChange={{this.setRole}}
-                      @selected={{this.selectedRole}}
-                      @selectedAdministrativeUnit={{this.selectedOrganization}}
-                      @id="minister-position-function"
-                    />
-                  </:content>
-                </Item>
-              {{/if}}
-            </:left>
-            <:right as |Item|>
-              {{#if
-                (and
-                  (eq this.positionType "Mandaat")
-                  this.governingBodyClassifications
-                  this.selectedRole
-                )
-              }}
+    {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+    editing code, we will use it for positions unavailable in Loket --}}
+    {{#if this.positionsCantBeCreatedOrEdited}}
+      <div>
+        Op dit moment kan je geen nieuwe personen aanmaken. De posities van mandatarissen, bestuursleden en
+        bedienaren (voor erediensten) worden automatisch ge-update door de bestuurseenheden zelf. Merk je dat
+        een positie of persoon niet wordt vermeld of de data is verkeerd, meld dit via onze
+        <a href="https://binnenland.atlassian.net/servicedesk/customer/portal/13" class="au-c-link">helpdesk</a>.
+        We verzoeken dan de besturen om deze data aan te passen. Samen houden we het OrganisatiePortaal up-to-date!
+      </div>
+    {{else}}
+      <form id="person-creation" {{on "submit" this.redirect}}>
+        <EditCard @containsRequiredFields={{true}}>
+          <:title>Selecteer</:title>
+          <:card as |Card|>
+            <Card.Columns>
+              <:left as |Item|>
                 <Item
-                  @labelFor="governing-body-classification"
+                  @labelFor="position-type"
                   @alignTop={{true}}
+                  @required={{true}}
                 >
-                  <:label>Bestuursorgaan</:label>
+                  <:label>Type</:label>
                   <:content>
                     <PowerSelect
-                      @options={{this.governingBodyClassifications}}
-                      @selected={{this.selectedClassification}}
-                      @onChange={{this.setClassification}}
-                      @triggerId="governing-body-classification"
-                      as |classification|
+                      @options={{this.positionTypes}}
+                      @selected={{this.positionType}}
+                      @onChange={{this.setPositionType}}
+                      @triggerId="position-type"
+                      as |positionType|
                     >
-                      {{classification.label}}
+                      {{positionType}}
                     </PowerSelect>
                   </:content>
                 </Item>
-                {{#if this.governingBodies}}
-                  <Item @labelFor="governing-body" @alignTop={{true}}>
-                    <:label>Bestuursperiode</:label>
-                    <:content>
-                      <PowerSelect
-                        @options={{this.governingBodies}}
-                        @selected={{this.selectedGoverningBody}}
-                        @onChange={{this.setGoverningBody}}
-                        @triggerId="governing-body"
-                        as |governingBody|
-                      >
+              </:left>
+            </Card.Columns>
+            <Card.Columns>
+              <:left as |Item|>
+                {{#if this.positionType}}
+              <Item
+                  @labelFor="organization"
+                  @required={{true}}
+                >
+                  <:label>Naam bestuur</:label>
+                  <:content>
+                    <AdministrativeUnitSelect
+                      @classificationCodes={{this.classificationCodes}}
+                      @selected={{this.selectedOrganization}}
+                      @onChange={{this.setOrganization}}
+                      id="organization"
+                    />
+                  </:content>
+                </Item>
+                {{/if}}
 
-                        {{governingBody.period}}
-                      </PowerSelect>
+                {{#if
+                  (and
+                    (eq this.positionType "Mandaat")
+                    this.governingBodyClassifications
+                  )
+                }}
+                  <Item @labelFor="board-position-code" @required={{true}}>
+                    <:label>Mandaat</:label>
+                    <:content>
+                      <MandateRoleSelect
+                        @selected={{this.selectedRole}}
+                        @selectedAdministrativeUnit={{this.selectedOrganization}}
+                        @onChange={{this.setRole}}
+                        @id="board-position-code"
+                      />
                     </:content>
                   </Item>
                 {{/if}}
-              {{/if}}
-            </:right>
+                {{#if (and this.selectedOrganization (eq this.positionType "Bedienaar"))}}
+                  <Item @labelFor="minister-position-function" @required={{true}}>
+                    <:label>Rol</:label>
+                    <:content>
+                      <MinisterPositionFunctionSelect
+                        @onChange={{this.setRole}}
+                        @selected={{this.selectedRole}}
+                        @selectedAdministrativeUnit={{this.selectedOrganization}}
+                        @id="minister-position-function"
+                      />
+                    </:content>
+                  </Item>
+                {{/if}}
+              </:left>
+              <:right as |Item|>
+                {{#if
+                  (and
+                    (eq this.positionType "Mandaat")
+                    this.governingBodyClassifications
+                    this.selectedRole
+                  )
+                }}
+                  <Item
+                    @labelFor="governing-body-classification"
+                    @alignTop={{true}}
+                  >
+                    <:label>Bestuursorgaan</:label>
+                    <:content>
+                      <PowerSelect
+                        @options={{this.governingBodyClassifications}}
+                        @selected={{this.selectedClassification}}
+                        @onChange={{this.setClassification}}
+                        @triggerId="governing-body-classification"
+                        as |classification|
+                      >
+                        {{classification.label}}
+                      </PowerSelect>
+                    </:content>
+                  </Item>
+                  {{#if this.governingBodies}}
+                    <Item @labelFor="governing-body" @alignTop={{true}}>
+                      <:label>Bestuursperiode</:label>
+                      <:content>
+                        <PowerSelect
+                          @options={{this.governingBodies}}
+                          @selected={{this.selectedGoverningBody}}
+                          @onChange={{this.setGoverningBody}}
+                          @triggerId="governing-body"
+                          as |governingBody|
+                        >
 
-          </Card.Columns>
+                          {{governingBody.period}}
+                        </PowerSelect>
+                      </:content>
+                    </Item>
+                  {{/if}}
+                {{/if}}
+              </:right>
 
-        </:card>
-      </EditCard>
-    </form>
+            </Card.Columns>
+
+          </:card>
+        </EditCard>
+      </form>
+    {{/if}}
   </div>
 </AuBodyContainer>

--- a/app/templates/people/person/personal-information/index.hbs
+++ b/app/templates/people/person/personal-information/index.hbs
@@ -9,14 +9,18 @@
       <:action>
         <SecuredArea>
           <:edit>
-            <AuLink
-              @route="people.person.personal-information.edit"
-              @skin="button-secondary"
-              @icon="pencil"
-              @iconAlignment="left"
-            >
-              Bewerk
-            </AuLink>
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#unless this.positionsCantBeCreatedOrEdited}}
+              <AuLink
+                @route="people.person.personal-information.edit"
+                @skin="button-secondary"
+                @icon="pencil"
+                @iconAlignment="left"
+              >
+                Bewerk
+              </AuLink>
+            {{/unless}}
           </:edit>
           <:readOnly>
             <ReportWrongData />

--- a/app/templates/people/person/positions/mandatory/index.hbs
+++ b/app/templates/people/person/positions/mandatory/index.hbs
@@ -20,7 +20,9 @@
         <:action>
           <SecuredArea>
             <:edit>
-              {{#if this.isWorshipAdministrativeUnit}}
+              {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+              editing code, we will use it for positions unavailable in Loket --}}
+              {{#if (and this.isWorshipAdministrativeUnit (not this.positionsCantBeCreatedOrEdited))}}
                 <Button::Edit
                   @route="administrative-units.administrative-unit.governing-bodies.governing-body.mandatory.edit"
                   @models={{array

--- a/app/templates/people/person/positions/minister/index.hbs
+++ b/app/templates/people/person/positions/minister/index.hbs
@@ -14,14 +14,18 @@
       <:action>
         <SecuredArea>
           <:edit>
-            <AuLink
-              @route="people.person.positions.minister.edit"
-              @skin="button-secondary"
-              @icon="pencil"
-              @iconAlignment="left"
-            >
-              Bewerk
-            </AuLink>
+            {{!-- Disabling positions editing from 01/02/2022. Don't remove position
+            editing code, we will use it for positions unavailable in Loket --}}
+            {{#unless this.positionsCantBeCreatedOrEdited}}
+              <AuLink
+                @route="people.person.positions.minister.edit"
+                @skin="button-secondary"
+                @icon="pencil"
+                @iconAlignment="left"
+              >
+                Bewerk
+              </AuLink>
+            {{/unless}}
           </:edit>
           <:readOnly>
             <ReportWrongData />


### PR DESCRIPTION
OP-2032

This will not be testable by the testers, what I did to test locally was to update the `new Date('2023-02-01')` by today's date.
As it'll not be tested by the testers, an extensive testing of this one would be valuable :smile: Thanks !