### PR TITLE
Added new classification identifiers to select by name

### DIFF
--- a/app/components/administrative-unit-select-by-name.js
+++ b/app/components/administrative-unit-select-by-name.js
@@ -22,11 +22,17 @@ export default class AdministrativeUnitSelectByNameComponent extends Component {
     } else {
       filter['classification_id'] = `
         ${CLASSIFICATION.AGB.id},
-         ${CLASSIFICATION.APB.id},
-         ${CLASSIFICATION.MUNICIPALITY.id}
-         ${CLASSIFICATION.PROVINCE.id}
-         ${CLASSIFICATION.OCMW.id}
-         ${CLASSIFICATION.DISTRICT.id}
+        ${CLASSIFICATION.APB.id},
+        ${CLASSIFICATION.MUNICIPALITY.id},
+        ${CLASSIFICATION.PROVINCE.id},
+        ${CLASSIFICATION.OCMW.id},
+        ${CLASSIFICATION.DISTRICT.id},
+        ${CLASSIFICATION.PROJECTVERENIGING.id},
+        ${CLASSIFICATION.DIENSTVERLENENDE_VERENIGING.id},
+        ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING.id},
+        ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME.id},
+        ${CLASSIFICATION.POLICE_ZONE.id},
+        ${CLASSIFICATION.ASSISTANCE_ZONE.id},
        `;
     }
 


### PR DESCRIPTION
The classification identifiers for the new kind of units were missing, causing them not to show up as completion suggestions when searching by name.