### PR TITLE
Moved duplicate classification identifier selection to util

### DIFF
--- a/app/components/administrative-unit-select-by-name.js
+++ b/app/components/administrative-unit-select-by-name.js
@@ -16,7 +16,7 @@ export default class AdministrativeUnitSelectByNameComponent extends Component {
     }
 
     filter['classification_id'] = getClassificationIds(
-      this.currentSession.hasWorshipRole,
+      this.currentSession.hasWorshipRole
     );
 
     const result = yield this.muSearch.search({

--- a/app/components/administrative-unit-select-by-name.js
+++ b/app/components/administrative-unit-select-by-name.js
@@ -1,8 +1,8 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
 import { restartableTask } from 'ember-concurrency';
+import { selectByRole as getClassificationIds } from 'frontend-organization-portal/utils/classification-identifiers';
 
-import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 export default class AdministrativeUnitSelectByNameComponent extends Component {
   @service muSearch;
   @service currentSession;
@@ -14,27 +14,10 @@ export default class AdministrativeUnitSelectByNameComponent extends Component {
     if (searchParams.trim() !== '') {
       filter[`:phrase_prefix:name`] = searchParams;
     }
-    if (this.currentSession.hasWorshipRole) {
-      filter['classification_id'] = `
-         ${CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id},
-         ${CLASSIFICATION.WORSHIP_SERVICE.id},
-        `;
-    } else {
-      filter['classification_id'] = `
-        ${CLASSIFICATION.AGB.id},
-        ${CLASSIFICATION.APB.id},
-        ${CLASSIFICATION.MUNICIPALITY.id},
-        ${CLASSIFICATION.PROVINCE.id},
-        ${CLASSIFICATION.OCMW.id},
-        ${CLASSIFICATION.DISTRICT.id},
-        ${CLASSIFICATION.PROJECTVERENIGING.id},
-        ${CLASSIFICATION.DIENSTVERLENENDE_VERENIGING.id},
-        ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING.id},
-        ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME.id},
-        ${CLASSIFICATION.POLICE_ZONE.id},
-        ${CLASSIFICATION.ASSISTANCE_ZONE.id},
-       `;
-    }
+
+    filter['classification_id'] = getClassificationIds(
+      this.currentSession.hasWorshipRole,
+    );
 
     const result = yield this.muSearch.search({
       index: 'units',

--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -1,11 +1,12 @@
 import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import { keepLatestTask } from 'ember-concurrency';
-import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
+import { selectByRole as getClassificationIds } from 'frontend-organization-portal/utils/classification-identifiers';
 
 export default class AdministrativeUnitsIndexRoute extends Route {
   @service muSearch;
   @service currentSession;
+
   queryParams = {
     page: { refreshModel: true },
     sort: { refreshModel: true },
@@ -40,27 +41,9 @@ export default class AdministrativeUnitsIndexRoute extends Route {
     if (params.classificationId) {
       filter['classification_id'] = params.classificationId;
     } else {
-      if (this.currentSession.hasWorshipRole) {
-        filter['classification_id'] = `
-          ${CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id},
-          ${CLASSIFICATION.WORSHIP_SERVICE.id},
-        `;
-      } else {
-        filter['classification_id'] = `
-          ${CLASSIFICATION.AGB.id},
-          ${CLASSIFICATION.APB.id},
-          ${CLASSIFICATION.MUNICIPALITY.id},
-          ${CLASSIFICATION.PROVINCE.id},
-          ${CLASSIFICATION.OCMW.id},
-          ${CLASSIFICATION.DISTRICT.id},
-          ${CLASSIFICATION.PROJECTVERENIGING.id},
-          ${CLASSIFICATION.DIENSTVERLENENDE_VERENIGING.id},
-          ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING.id},
-          ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME.id},
-          ${CLASSIFICATION.POLICE_ZONE.id},
-          ${CLASSIFICATION.ASSISTANCE_ZONE.id},
-        `;
-      }
+      filter['classification_id'] = getClassificationIds(
+        this.currentSession.hasWorshipRole,
+      );
     }
 
     if (params.municipality) {

--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -42,7 +42,7 @@ export default class AdministrativeUnitsIndexRoute extends Route {
       filter['classification_id'] = params.classificationId;
     } else {
       filter['classification_id'] = getClassificationIds(
-        this.currentSession.hasWorshipRole,
+        this.currentSession.hasWorshipRole
       );
     }
 

--- a/app/utils/classification-identifiers.js
+++ b/app/utils/classification-identifiers.js
@@ -1,0 +1,23 @@
+import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
+
+export function selectByRole(hasWorshipRole) {
+  if (hasWorshipRole) {
+    return `${CLASSIFICATION.CENTRAL_WORSHIP_SERVICE.id},
+          ${CLASSIFICATION.WORSHIP_SERVICE.id},
+        `;
+  } else {
+    return `${CLASSIFICATION.AGB.id},
+          ${CLASSIFICATION.APB.id},
+          ${CLASSIFICATION.MUNICIPALITY.id},
+          ${CLASSIFICATION.PROVINCE.id},
+          ${CLASSIFICATION.OCMW.id},
+          ${CLASSIFICATION.DISTRICT.id},
+          ${CLASSIFICATION.PROJECTVERENIGING.id},
+          ${CLASSIFICATION.DIENSTVERLENENDE_VERENIGING.id},
+          ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING.id},
+          ${CLASSIFICATION.OPDRACHTHOUDENDE_VERENIGING_MET_PRIVATE_DEELNAME.id},
+          ${CLASSIFICATION.POLICE_ZONE.id},
+          ${CLASSIFICATION.ASSISTANCE_ZONE.id},
+        `;
+  }
+}


### PR DESCRIPTION
As a follow-up to #512 I moved the duplicated code to a util to prevent similar oversights in the future.