### PR TITLE
Allow underscores in identifier search field

### DIFF
--- a/app/helpers/format-identifier.js
+++ b/app/helpers/format-identifier.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
 export function formatIdentifier([identifier]) {
-  return identifier.replace(/[^a-z0-9]/gi, '');
+  return identifier.replace(/[^\w]/gi, '');
 }
 
 export default helper(formatIdentifier);


### PR DESCRIPTION
OP-2747: allow underscores in search string as they are used for SharePoint identifiers