### PR TITLE
Feature: show error message underneath save button when a form contains errors

### DIFF
--- a/app/components/error/save.hbs
+++ b/app/components/error/save.hbs
@@ -1,0 +1,4 @@
+{{#if @showSaveError}}
+  <AuHelpText @error={{true}}>Je kan deze pagina niet opslaan omdat een
+    verplicht veld niet is ingevuld.</AuHelpText>
+{{/if}}

--- a/app/controllers/administrative-units/administrative-unit/change-events/details/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/details/edit.js
@@ -17,6 +17,14 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsDetailsEdi
   @tracked
   publicationDateValidation = { valid: true };
 
+  get hasValidationErrors() {
+    return (
+      !this.endDateValidation.valid ||
+      !this.publicationDateValidation.valid ||
+      this.model.changeEvent.isInvalid
+    );
+  }
+
   get isCityChangeEvent() {
     return (
       this.model.changeEvent.type &&

--- a/app/controllers/administrative-units/administrative-unit/change-events/new.js
+++ b/app/controllers/administrative-units/administrative-unit/change-events/new.js
@@ -33,10 +33,23 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsNewControl
 
   @tracked
   endDateValidation = { valid: true };
+
   @tracked
   publicationEndDateValidation = { valid: true };
+
   @tracked
   dateValidation = { valid: true };
+
+  get hasValidationErrors() {
+    return (
+      !this.dateValidation ||
+      !this.publicationEndDateValidation ||
+      !this.endDateValidation ||
+      this.model.decision.isInvalid ||
+      this.model.formState.isInvalid ||
+      this.model.changeEvent.isInvalid
+    );
+  }
 
   get isCentralWorshipService() {
     return this.model.formState.isCentralWorshipService;

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -9,6 +9,16 @@ import { CLASSIFICATION_CODE } from 'frontend-organization-portal/models/adminis
 export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController extends Controller {
   @service router;
 
+  get hasValidationErrors() {
+    return (
+      this.model.administrativeUnit.isInvalid ||
+      this.model.address.isInvalid ||
+      this.model.contact.isInvalid ||
+      this.model.secondaryContact.isInvalid ||
+      this.model.structuredIdentifierKBO.isInvalid
+    );
+  }
+
   get isWorshipAdministrativeUnit() {
     return this.isWorshipService || this.isCentralWorshipService;
   }
@@ -121,6 +131,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
   @dropTask
   *save(event) {
     event.preventDefault();
+
     let {
       administrativeUnit,
       address,
@@ -140,13 +151,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
       structuredIdentifierKBO.validate(),
     ]);
 
-    if (
-      administrativeUnit.isValid &&
-      address.isValid &&
-      contact.isValid &&
-      secondaryContact.isValid &&
-      structuredIdentifierKBO.isValid
-    ) {
+    if (!this.hasValidationErrors) {
       let primarySite = yield administrativeUnit.primarySite;
 
       // TODO : "if" not needed when the data of all administrative units will be correct

--- a/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/governing-bodies/governing-body/edit.js
@@ -17,6 +17,15 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
     this.startDateValidation = { valid: true };
     this.endDateValidation = { valid: true };
   }
+
+  get hasValidationErrors() {
+    return (
+      this.model.governingBody.isInvalid ||
+      !this.endDateValidation.valid ||
+      !this.startDateValidation.valid
+    );
+  }
+
   @action
   async validateStartDate(validation) {
     this.resetValidation();
@@ -43,11 +52,7 @@ export default class AdministrativeUnitsAdministrativeUnitGoverningBodiesGoverni
     event.preventDefault();
     yield this.model.governingBody.validate();
 
-    if (
-      this.model.governingBody.isValid &&
-      this.endDateValidation.valid &&
-      this.startDateValidation.valid
-    ) {
+    if (!this.hasValidationErrors) {
       yield this.model.governingBody.save();
 
       this.router.transitionTo(

--- a/app/controllers/administrative-units/administrative-unit/local-involvements/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/local-involvements/edit.js
@@ -20,6 +20,18 @@ export default class AdministrativeUnitsAdministrativeUnitLocalInvolvementsEditC
     CLASSIFICATION_CODE.PROVINCE,
   ];
 
+  get hasValidationErrors() {
+    let areSomeLocalInvolvementsInvalid = this.model.involvements
+      .toArray()
+      .some((involvement) => involvement.isInvalid);
+
+    return (
+      areSomeLocalInvolvementsInvalid ||
+      !this.isValidTotalFinancingPercentage ||
+      !this.isOneOrLessFinancialLocalInvolvement
+    );
+  }
+
   get isWorshipService() {
     return (
       this.model.worshipAdministrativeUnit.classification?.get('id') ===

--- a/app/controllers/administrative-units/administrative-unit/related-organizations/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/related-organizations/edit.js
@@ -10,6 +10,10 @@ export default class AdministrativeUnitsAdministrativeUnitRelatedOrganizationsEd
   @service router;
   @service store;
 
+  get hasValidationErrors() {
+    return this.model.administrativeUnit.isInvalid;
+  }
+
   queryParams = ['sort'];
 
   @tracked sort = 'name';

--- a/app/controllers/administrative-units/administrative-unit/sites/new.js
+++ b/app/controllers/administrative-units/administrative-unit/sites/new.js
@@ -10,6 +10,15 @@ export default class AdministrativeUnitsAdministrativeUnitSitesNewController ext
   @service store;
   @tracked isPrimarySite = false;
 
+  get hasValidationErrors() {
+    return (
+      this.model.site.isInvalid ||
+      this.model.address.isInvalid ||
+      this.model.contact.isInvalid ||
+      this.model.secondaryContact.isInvalid
+    );
+  }
+
   @dropTask
   *createSiteTask(event) {
     event.preventDefault();
@@ -22,12 +31,7 @@ export default class AdministrativeUnitsAdministrativeUnitSitesNewController ext
     yield contact.validate();
     yield secondaryContact.validate();
 
-    if (
-      site.isValid &&
-      address.isValid &&
-      contact.isValid &&
-      secondaryContact.isValid
-    ) {
+    if (!this.hasValidationErrors) {
       contact = setEmptyStringsToNull(contact);
       yield contact.save();
 

--- a/app/controllers/administrative-units/administrative-unit/sites/site/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/sites/site/edit.js
@@ -19,6 +19,15 @@ export default class AdministrativeUnitsAdministrativeUnitSitesSiteEditControlle
     this.isPrimarySite = this.isCurrentPrimarySite;
   }
 
+  get hasValidationErrors() {
+    return (
+      this.model.site.isInvalid ||
+      this.model.address.isInvalid ||
+      this.model.contact.isInvalid ||
+      this.model.secondaryContact.isInvalid
+    );
+  }
+
   @action
   updateIsPrimarySite(isPrimarySite) {
     this.isPrimarySite = isPrimarySite;
@@ -48,12 +57,7 @@ export default class AdministrativeUnitsAdministrativeUnitSitesSiteEditControlle
     yield contact.validate();
     yield secondaryContact.validate();
 
-    if (
-      site.isValid &&
-      address.isValid &&
-      contact.isValid &&
-      secondaryContact.isValid
-    ) {
+    if (!this.hasValidationErrors) {
       if (address.isDirty) {
         if (address.country != 'België') {
           address.province = '';

--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -12,6 +12,16 @@ export default class AdministrativeUnitsNewController extends Controller {
   @service router;
   @service store;
 
+  get hasValidationErrors() {
+    return (
+      this.model.administrativeUnitChangeset.isInvalid ||
+      this.model.address.isInvalid ||
+      this.model.contact.isInvalid ||
+      this.model.secondaryContact.isInvalid ||
+      this.model.structuredIdentifierKBO.isInvalid
+    );
+  }
+
   get isNewOCMW() {
     return (
       this.model.administrativeUnitChangeset.classification?.id ===
@@ -181,13 +191,7 @@ export default class AdministrativeUnitsNewController extends Controller {
       structuredIdentifierKBO.validate(),
     ]);
 
-    if (
-      administrativeUnitChangeset.isValid &&
-      address.isValid &&
-      contact.isValid &&
-      secondaryContact.isValid &&
-      structuredIdentifierKBO.isValid
-    ) {
+    if (!this.hasValidationErrors) {
       const siteTypes = yield this.store.findAll('site-type');
       let newAdministrativeUnit;
       // Set the proper type to the new admin unit

--- a/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
@@ -15,24 +15,28 @@
         Bewerk veranderingsgebeurtenis:
         {{@model.changeEvent.type.label}}
       </:title>
-      <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.name}}
+        ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
-        <AuButtonGroup>
-          <AuLink
-            @route="administrative-units.administrative-unit.change-events.details"
-            @model={{@model.changeEvent.id}}
-            @skin="button-secondary"
-          >
-            Annuleer
-          </AuLink>
-          <AuButton
-            @loading={{this.save.isRunning}}
-            @disabled={{this.save.isRunning}}
-            type="submit"
-          >
-            Opslaan
-          </AuButton>
-        </AuButtonGroup>
+        <div class="au-u-text-right">
+          <AuButtonGroup class="au-c-button-group--align-right">
+            <AuLink
+              @route="administrative-units.administrative-unit.change-events.details"
+              @model={{@model.changeEvent.id}}
+              @skin="button-secondary"
+            >
+              Annuleer
+            </AuLink>
+            <AuButton
+              @loading={{this.save.isRunning}}
+              @disabled={{this.save.isRunning}}
+              type="submit"
+            >
+              Opslaan
+            </AuButton>
+          </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
+        </div>
       </:action>
     </PageHeader>
 
@@ -77,15 +81,18 @@
             {{/if}}
           </:left>
           <:right as |Item|>
-            {{#if (and
-              (not this.isAgbOrApb)
-              (not this.isIgs)
-              (not this.isPoliceZone)
-              (not this.isAssistanceZone)
-              @model.canAddDecisionInformation
-            )}}
+            {{#if
+              (and
+                (not this.isAgbOrApb)
+                (not this.isIgs)
+                (not this.isPoliceZone)
+                (not this.isAssistanceZone)
+                @model.canAddDecisionInformation
+              )
+            }}
               {{#unless this.isCityChangeEvent}}
-                <Item @labelFor="change-event-decision-activity-date"
+                <Item
+                  @labelFor="change-event-decision-activity-date"
                   @errorMessage={{this.endDateValidation.errorMessage}}
                 >
                   <:label>Datum ministerieel besluit</:label>
@@ -100,7 +107,8 @@
                   </:content>
                 </Item>
               {{/unless}}
-              <Item @labelFor="change-event-decision-publication-date"
+              <Item
+                @labelFor="change-event-decision-publication-date"
                 @errorMessage={{this.publicationDateValidation.errorMessage}}
               >
                 <:label>

--- a/app/templates/administrative-units/administrative-unit/change-events/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/new.hbs
@@ -12,23 +12,27 @@
   >
     <PageHeader>
       <:title>Voeg veranderingsgebeurtenis toe</:title>
-      <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.name}}
+        ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
-        <AuButtonGroup>
-          <AuLink
-            @route="administrative-units.administrative-unit.change-events"
-            @skin="button-secondary"
-          >
-            Annuleer
-          </AuLink>
-          <AuButton
-            @loading={{this.createNewChangeEventTask.isRunning}}
-            @disabled={{this.createNewChangeEventTask.isRunning}}
-            type="submit"
-          >
-            Opslaan
-          </AuButton>
-        </AuButtonGroup>
+        <div class="au-u-text-right">
+          <AuButtonGroup class="au-c-button-group--align-right">
+            <AuLink
+              @route="administrative-units.administrative-unit.change-events"
+              @skin="button-secondary"
+            >
+              Annuleer
+            </AuLink>
+            <AuButton
+              @loading={{this.createNewChangeEventTask.isRunning}}
+              @disabled={{this.createNewChangeEventTask.isRunning}}
+              type="submit"
+            >
+              Opslaan
+            </AuButton>
+          </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
+        </div>
       </:action>
     </PageHeader>
 
@@ -85,15 +89,18 @@
             {{/if}}
           </:left>
           <:right as |Item|>
-            {{#if (and
-              (not this.isAgbOrApb)
-              (not this.isIgs)
-              (not this.isPoliceZone)
-              (not this.isAssistanceZone)
-              @model.formState.canAddDecisionInformation
-            )}}
+            {{#if
+              (and
+                (not this.isAgbOrApb)
+                (not this.isIgs)
+                (not this.isPoliceZone)
+                (not this.isAssistanceZone)
+                @model.formState.canAddDecisionInformation
+              )
+            }}
               {{#unless @model.formState.isCityChangeEvent}}
-                <Item @labelFor="change-event-decision-activity-date"
+                <Item
+                  @labelFor="change-event-decision-activity-date"
                   @errorMessage={{this.endDateValidation.errorMessage}}
                 >
                   <:label>Datum ministerieel besluit</:label>
@@ -108,16 +115,21 @@
                   </:content>
                 </Item>
               {{/unless}}
-              <Item @labelFor="change-event-decision-publication-date"
+              <Item
+                @labelFor="change-event-decision-publication-date"
                 @errorMessage={{this.publicationEndDateValidation.errorMessage}}
               >
                 <:label>
-                  {{#if (and (not this.isAgbOrApb) @model.formState.isCityChangeEvent)}}
+                  {{#if
+                    (and
+                      (not this.isAgbOrApb) @model.formState.isCityChangeEvent
+                    )
+                  }}
                     Datum besluit
                   {{else}}
                     Datum publicatie BS
                   {{/if}}
-                  </:label>
+                </:label>
                 <:content as |hasError|>
                   <Datepicker
                     @error={{hasError}}

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -2,9 +2,10 @@
   <div class="au-o-box">
     <PageHeader class="au-u-margin-bottom-large">
       <:title>Bewerk kerngegevens</:title>
-      <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.name}}
+        ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
-        <div>
+        <div class="au-u-text-right">
           <AuButtonGroup class="au-c-button-group--align-right">
             <AuLink
               @route="administrative-units.administrative-unit.core-data"
@@ -21,6 +22,7 @@
               Opslaan
             </AuButton>
           </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
           <ReportWrongData />
         </div>
       </:action>
@@ -52,9 +54,11 @@
                       @error={{hasError}}
                       id="worship-service-name"
                     />
-                      {{#if (or this.isProvince this.isMunicipality)}}
+                    {{#if (or this.isProvince this.isMunicipality)}}
                       <AuHelpText>
-        De naam van een gemeente en provincie kan voorlopig niet langer aangepast worden. Indien toch een aanpassing nodig, gelieve deze via de helpdesk aan te vragen.
+                        De naam van een gemeente en provincie kan voorlopig niet
+                        langer aangepast worden. Indien toch een aanpassing
+                        nodig, gelieve deze via de helpdesk aan te vragen.
                       </AuHelpText>
                     {{/if}}
                   </:content>
@@ -102,7 +106,9 @@
                       <TrimInput
                         @width="block"
                         @value={{@model.administrativeUnit.denomination}}
-                        @onUpdate={{fn (mut @model.administrativeUnit.denomination)}}
+                        @onUpdate={{fn
+                          (mut @model.administrativeUnit.denomination)
+                        }}
                         id="denomination"
                       />
                     </:content>
@@ -152,7 +158,7 @@
                   </Item>
                 {{/if}}
                 {{#if this.isIgs}}
-                  <Item @labelFor="igs-regio" >
+                  <Item @labelFor="igs-regio">
                     <:label>Regio</:label>
                     <:content>
                       <TrimInput
@@ -163,13 +169,13 @@
                       />
                     </:content>
                   </Item>
-                  <Item 
-                    @labelFor="expectedEndDate" 
+                  <Item
+                    @labelFor="expectedEndDate"
                     @errorMessage={{@model.administrativeUnit.error.expectedEndDate.validation}}
                   >
                     <:label>Geplande einddatum</:label>
-                    <:content  as |hasError|>
-                      <Datepicker 
+                    <:content as |hasError|>
+                      <Datepicker
                         @onChange={{fn
                           (mut @model.administrativeUnit.expectedEndDate)
                         }}
@@ -183,9 +189,7 @@
                     <:content>
                       <AuTextarea
                         @width="block"
-                        @onChange={{fn
-                          (mut @model.administrativeUnit.purpose)
-                        }}
+                        @onChange={{fn (mut @model.administrativeUnit.purpose)}}
                         @value={{@model.administrativeUnit.purpose}}
                       />
                     </:content>
@@ -240,7 +244,9 @@
                     <TrimInput
                       @width="block"
                       @value={{@model.structuredIdentifierSharepoint.localId}}
-                      @onUpdate={{fn (mut @model.structuredIdentifierSharepoint.localId)}}
+                      @onUpdate={{fn
+                        (mut @model.structuredIdentifierSharepoint.localId)
+                      }}
                       id="sharepoint-identifier"
                     />
                   </:content>
@@ -254,12 +260,12 @@
                   </Item>
                 {{/if}}
                 {{#if @model.structuredIdentifierOVO.localId}}
-                <Item @labelFor="ovo-identifier">
-                  <:label>{{@model.identifierOVO.idName}}</:label>
-                  <:content>
-                    {{@model.structuredIdentifierOVO.localId}}
-                  </:content>
-                </Item>
+                  <Item @labelFor="ovo-identifier">
+                    <:label>{{@model.identifierOVO.idName}}</:label>
+                    <:content>
+                      {{@model.structuredIdentifierOVO.localId}}
+                    </:content>
+                  </Item>
                 {{/if}}
               </:right>
             </Card.Columns>
@@ -279,16 +285,31 @@
           <:title>Primaire contactgegevens</:title>
         </Site::ContactEditCard>
 
-        {{#if (
-          and @model.administrativeUnit.classification
-          (or this.isAgb this.isApb this.isIgs this.isPoliceZone this.isAssistanceZone)
-        )}}
+        {{#if
+          (and
+            @model.administrativeUnit.classification
+            (or
+              this.isAgb
+              this.isApb
+              this.isIgs
+              this.isPoliceZone
+              this.isAssistanceZone
+            )
+          )
+        }}
           <EditCard @containsRequiredFields={{true}}>
             <:title>Gerelateerde organisaties</:title>
             <:card as |Card|>
-                <Card.Columns>
-                  <:left as |Item|>
-                  {{#if (or this.isAgb this.isIgs this.isPoliceZone this.isAssistanceZone)}}
+              <Card.Columns>
+                <:left as |Item|>
+                  {{#if
+                    (or
+                      this.isAgb
+                      this.isIgs
+                      this.isPoliceZone
+                      this.isAssistanceZone
+                    )
+                  }}
                     <Item
                       @labelFor="related-gemeente"
                       @required={{true}}
@@ -325,14 +346,14 @@
                       >
                         <:label>Werd opgericht door</:label>
                         <:content as |hasError|>
-                        <AdministrativeUnitSelect
-                          @disabled={{true}}
-                          @selected={{@model.administrativeUnit.wasFoundedByOrganization}}
-                          @onChange={{this.setRelation}}
-                          @classificationCodes={{this.classificationCodes}}
-                          @error={{hasError}}
-                          @id="oprichting-gemeente"
-                        />
+                          <AdministrativeUnitSelect
+                            @disabled={{true}}
+                            @selected={{@model.administrativeUnit.wasFoundedByOrganization}}
+                            @onChange={{this.setRelation}}
+                            @classificationCodes={{this.classificationCodes}}
+                            @error={{hasError}}
+                            @id="oprichting-gemeente"
+                          />
                         </:content>
                       </Item>
                     {{/if}}
@@ -345,33 +366,32 @@
                       >
                         <:label>Heeft als participanten</:label>
                         <:content as |hasError|>
-                        <AdministrativeUnitMultipleSelect
-                          @selected={{@model.administrativeUnit.hasParticipants}}
-                          @onChange={{this.setHasParticipants}}
-                          @classificationCodes={{this.classificationCodesIgsParticipants}}
-                          @error={{hasError}}
-                          @id="has-participants"
-                        />
+                          <AdministrativeUnitMultipleSelect
+                            @selected={{@model.administrativeUnit.hasParticipants}}
+                            @onChange={{this.setHasParticipants}}
+                            @classificationCodes={{this.classificationCodesIgsParticipants}}
+                            @error={{hasError}}
+                            @id="has-participants"
+                          />
                         </:content>
                       </Item>
                     {{/if}}
                   {{else}}
-                      <Item
-                        @labelFor="related-provincie"
-                        @required={{true}}
-                        @errorMessage={{@model.administrativeUnit.error.isSubOrganizationOf.validation}}
-                      >
-                        <:label>Provincie</:label>
-                        <:content as |hasError|>
-                          <ProvinceOrganizationSelect
-                            @selected={{@model.administrativeUnit.isSubOrganizationOf}}
-                            @onChange={{this.setRelation
-                            }}
-                            @error={{hasError}}
-                            @id="related-provincie"
-                          />
-                        </:content>
-                      </Item>
+                    <Item
+                      @labelFor="related-provincie"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnit.error.isSubOrganizationOf.validation}}
+                    >
+                      <:label>Provincie</:label>
+                      <:content as |hasError|>
+                        <ProvinceOrganizationSelect
+                          @selected={{@model.administrativeUnit.isSubOrganizationOf}}
+                          @onChange={{this.setRelation}}
+                          @error={{hasError}}
+                          @id="related-provincie"
+                        />
+                      </:content>
+                    </Item>
                     <Item
                       @labelFor="related-gemeente"
                       @required={{true}}
@@ -390,27 +410,26 @@
                         />
                       </:content>
                     </Item>
-                      <Item
-                        @labelFor="opregicht-provincie"
-                        @required={{true}}
-                        @errorMessage={{@model.administrativeUnit.error.wasFoundedByOrganization.validation}}
-                      >
-                        <:label>Werd opgericht door</:label>
-                        <:content as |hasError|>
-                          <ProvinceOrganizationSelect
+                    <Item
+                      @labelFor="opregicht-provincie"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnit.error.wasFoundedByOrganization.validation}}
+                    >
+                      <:label>Werd opgericht door</:label>
+                      <:content as |hasError|>
+                        <ProvinceOrganizationSelect
                           @disabled={{true}}
-                            @selected={{@model.administrativeUnit.wasFoundedByOrganization}}
-                            @onChange={{this.setRelation
-                            }}
-                            @error={{hasError}}
-                            @id="opregicht-provincie"
-                          />
-                        </:content>
-                      </Item>
+                          @selected={{@model.administrativeUnit.wasFoundedByOrganization}}
+                          @onChange={{this.setRelation}}
+                          @error={{hasError}}
+                          @id="opregicht-provincie"
+                        />
+                      </:content>
+                    </Item>
 
-                    {{/if}}
-                  </:left>
-                </Card.Columns>
+                  {{/if}}
+                </:left>
+              </Card.Columns>
             </:card>
           </EditCard>
         {{/if}}

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/board-member/new.hbs
@@ -13,7 +13,7 @@
             @skin="button-secondary"
           >
             Annuleer
-          </AuLink>          
+          </AuLink>
           <AuButton
             @icon="add"
             @iconAlignment="left"
@@ -43,11 +43,16 @@
       {{on "submit" (perform this.createMandatoryPositionTask)}}
     >
 
-    {{#if this.targetPersonError}}
-      <AuAlert @alertIcon="alert-triangle" @alertTitle="Er is een onverwachte fout opgetreden." @alertSkin="error">
-        <p>Probeer de persoon opnieuw aan de positie toe te voegen. Als het niet lukt, neem dan contact met ons op.</p>
-      </AuAlert>
-    {{/if}}
+      {{#if this.targetPersonError}}
+        <AuAlert
+          @alertIcon="alert-triangle"
+          @alertTitle="Er is een onverwachte fout opgetreden."
+          @alertSkin="error"
+        >
+          <p>Probeer de persoon opnieuw aan de positie toe te voegen. Als het
+            niet lukt, neem dan contact met ons op.</p>
+        </AuAlert>
+      {{/if}}
 
       <DataCard>
         <:title>Persoonlijke gegevens</:title>
@@ -145,7 +150,7 @@
                 @labelFor="start-date"
                 @required={{true}}
                 @errorMessage={{this.startDateErrorMessage}}
-               >
+              >
                 <:label>Start mandaat</:label>
                 <:content as |errorMessage|>
                   <Datepicker
@@ -158,7 +163,10 @@
                 </:content>
               </Item>
               {{#if this.isWorshipAdministrativeUnit}}
-                <Item @labelFor="expected-end-date" @errorMessage={{this.expectedEndDateErrorMessage}}>
+                <Item
+                  @labelFor="expected-end-date"
+                  @errorMessage={{this.expectedEndDateErrorMessage}}
+                >
                   <:label>Geplande einddatum</:label>
                   <:content as |errorMessage|>
                     <Datepicker

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
@@ -8,7 +8,7 @@
         ({{@model.administrativeUnit.classification.label}})
       </:subtitle>
       <:action>
-        <div>
+        <div class="au-u-text-right">
           <AuButtonGroup class="au-c-button-group--align-right">
             <AuButton {{on "click" this.cancel}} @skin="secondary">
               Annuleer
@@ -22,6 +22,7 @@
               Opslaan
             </AuButton>
           </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
           <ReportWrongData />
         </div>
       </:action>

--- a/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
@@ -4,7 +4,7 @@
     <:title>Bewerk betrokken lokale besturen</:title>
     <:subtitle>{{@model.worshipAdministrativeUnit.name}}</:subtitle>
     <:action>
-      <div>
+      <div class="au-u-text-right">
         <AuButtonGroup class="au-c-button-group--align-right">
           <AuLink
             @route="administrative-units.administrative-unit.local-involvements"
@@ -21,6 +21,7 @@
             Opslaan
           </AuButton>
         </AuButtonGroup>
+        <Error::Save @showSaveError={{this.hasValidationErrors}} />
         <ReportWrongData />
       </div>
     </:action>

--- a/app/templates/administrative-units/administrative-unit/related-organizations/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/related-organizations/edit.hbs
@@ -2,9 +2,10 @@
   <div class="au-o-box">
     <PageHeader class="au-u-margin-bottom-large">
       <:title>Bewerk gerelateerde organisaties</:title>
-      <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.name}}
+        ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
-        <div>
+        <div class="au-u-text-right">
           <AuButtonGroup class="au-c-button-group--align-right">
             <AuLink
               @route="administrative-units.administrative-unit.related-organizations"
@@ -22,6 +23,7 @@
             </AuButton>
           </AuButtonGroup>
           <ReportWrongData />
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
         </div>
       </:action>
     </PageHeader>
@@ -58,9 +60,7 @@
           />
         {{/if}}
         {{#if this.isOCMW}}
-          <RelatedOrganizations::EditOcmw
-            @model={{@model}}
-          />
+          <RelatedOrganizations::EditOcmw @model={{@model}} />
         {{/if}}
         {{#if this.isProvince}}
           <RelatedOrganizations::EditProvince

--- a/app/templates/administrative-units/administrative-unit/sites/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/new.hbs
@@ -3,24 +3,27 @@
     <PageHeader>
       <:title>Voeg vestiging toe</:title>
       <:action>
-        <AuButtonGroup class="au-c-button-group--align-right">
-          <AuLink
-            @route="administrative-units.administrative-unit.sites"
-            @skin="button-secondary"
-          >
-            Annuleer
-          </AuLink>
-          <AuButton
-            @loading={{this.createSiteTask.isRunning}}
-            @disabled={{this.createSiteTask.isRunning}}
-            @icon="add"
-            @iconAlignment="left"
-            type="submit"
-            form="new-vestiging-form"
-          >
-            Voeg toe
-          </AuButton>
-        </AuButtonGroup>
+        <div class="au-u-test-right">
+          <AuButtonGroup class="au-c-button-group--align-right">
+            <AuLink
+              @route="administrative-units.administrative-unit.sites"
+              @skin="button-secondary"
+            >
+              Annuleer
+            </AuLink>
+            <AuButton
+              @loading={{this.createSiteTask.isRunning}}
+              @disabled={{this.createSiteTask.isRunning}}
+              @icon="add"
+              @iconAlignment="left"
+              type="submit"
+              form="new-vestiging-form"
+            >
+              Voeg toe
+            </AuButton>
+          </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
+        </div>
       </:action>
     </PageHeader>
 
@@ -31,19 +34,19 @@
           <:card as |Card|>
             <Card.Columns>
               <:left as |Item|>
-                <Item @labelFor="site-type"
-                              @required={{true}}
-
-                      @errorMessage={{@model.site.error.siteType.validation}}>
+                <Item
+                  @labelFor="site-type"
+                  @required={{true}}
+                  @errorMessage={{@model.site.error.siteType.validation}}
+                >
                   <:label>Type vestiging</:label>
-                  <:content  as |hasError|>
+                  <:content as |hasError|>
                     <SiteTypeSelect
                       @selected={{@model.site.siteType}}
                       @onChange={{fn (mut @model.site.siteType)}}
                       @administrativeUnitClassification={{this.model.administrativeUnit.classification}}
                       @id="site-type"
                       @error={{hasError}}
-
                     />
                   </:content>
                 </Item>

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -7,7 +7,7 @@
         {{this.model.administrativeUnit.name}}
       </:subtitle>
       <:action>
-        <div>
+        <div class="au-u-text-right">
           <AuButtonGroup class="au-c-button-group--align-right">
             <AuLink
               @route="administrative-units.administrative-unit.sites.site"
@@ -24,6 +24,7 @@
               Opslaan
             </AuButton>
           </AuButtonGroup>
+          <Error::Save @showSaveError={{this.hasValidationErrors}} />
           <ReportWrongData />
         </div>
       </:action>
@@ -40,12 +41,13 @@
           <:card as |Card|>
             <Card.Columns>
               <:left as |Item|>
-                <Item @labelFor="site-type"
+                <Item
+                  @labelFor="site-type"
                   @required={{true}}
                   @errorMessage={{this.model.site.error.siteType.validation}}
                 >
                   <:label>Type vestiging</:label>
-                  <:content  as |hasError|>
+                  <:content as |hasError|>
                     <SiteTypeSelect
                       @selected={{this.model.site.siteType}}
                       @onChange={{fn (mut this.model.site.siteType)}}
@@ -57,9 +59,7 @@
                 </Item>
               </:left>
               <:right as |Item|>
-                <Item
-                  @errorMessage={{this.isNoPrimarySiteErrorMessage}}
-                >
+                <Item @errorMessage={{this.isNoPrimarySiteErrorMessage}}>
                   <:label>Primair correspondentieadres</:label>
                   <:content>
                     <ul class="au-c-list-inline">
@@ -96,7 +96,9 @@
           @primaryContact={{this.model.contact}}
           @secondaryContact={{this.model.secondaryContact}}
           @isAddressSearchEnabledInitially={{if
-              (or (not this.model.address.id) this.model.address.addressRegisterUri)
+            (or
+              (not this.model.address.id) this.model.address.addressRegisterUri
+            )
             true
             false
           }}

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -5,20 +5,23 @@
   <PageHeader class="au-u-margin au-u-margin-bottom-large">
     <:title>Voeg bestuurseenheid toe</:title>
     <:action>
-      <AuButtonGroup class="au-c-button-group--align-right">
-        <AuLink @route="administrative-units" @skin="button-secondary">
-          Annuleer
-        </AuLink>
-        <AuButton
-          @loading={{this.createAdministrativeUnitTask.isRunning}}
-          type="submit"
-          form="administrative-unit-creation-form"
-          @icon="add"
-          @iconAlignment="left"
-        >
-          Voeg toe
-        </AuButton>
-      </AuButtonGroup>
+      <div class="au-u-text-right">
+        <AuButtonGroup class="au-c-button-group--align-right">
+          <AuLink @route="administrative-units" @skin="button-secondary">
+            Annuleer
+          </AuLink>
+          <AuButton
+            @loading={{this.createAdministrativeUnitTask.isRunning}}
+            type="submit"
+            form="administrative-unit-creation-form"
+            @icon="add"
+            @iconAlignment="left"
+          >
+            Voeg toe
+          </AuButton>
+        </AuButtonGroup>
+        <Error::Save @showSaveError={{this.hasValidationErrors}} />
+      </div>
     </:action>
   </PageHeader>
 
@@ -77,7 +80,9 @@
                   <RecognizedWorshipTypeSelect
                     @selected={{@model.administrativeUnitChangeset.recognizedWorshipType}}
                     @onChange={{fn
-                      (mut @model.administrativeUnitChangeset.recognizedWorshipType)
+                      (mut
+                        @model.administrativeUnitChangeset.recognizedWorshipType
+                      )
                     }}
                     @allowClear={{true}}
                     @error={{hasError}}
@@ -86,9 +91,9 @@
                 </:content>
               </Item>
             {{/if}}
-    {{#if this.isNewWorshipService}}
+            {{#if this.isNewWorshipService}}
               <Item @labelFor="denomination">
-    <:label>Strekking</:label>
+                <:label>Strekking</:label>
                 <:content>
                   <TrimInput
                     @width="block"
@@ -146,7 +151,7 @@
                 @errorMessage={{@model.administrativeUnitChangeset.error.expectedEndDate.validation}}
               >
                 <:label>Geplande einddatum</:label>
-                <:content  as |hasError|>
+                <:content as |hasError|>
                   <Datepicker
                     @onChange={{fn
                       (mut @model.administrativeUnitChangeset.expectedEndDate)
@@ -156,17 +161,17 @@
                 </:content>
               </Item>
               <Item @labelFor="purpose">
-                    <:label>Doel</:label>
-                    <:content>
-                      <AuTextarea
-                        @width="block"
-                        @onChange={{fn
-                          (mut @model.administrativeUnitChangeset.purpose)
-                        }}
-                        @value={{@model.administrativeUnitChangeset.purpose}}
-                      />
-                    </:content>
-                  </Item>
+                <:label>Doel</:label>
+                <:content>
+                  <AuTextarea
+                    @width="block"
+                    @onChange={{fn
+                      (mut @model.administrativeUnitChangeset.purpose)
+                    }}
+                    @value={{@model.administrativeUnitChangeset.purpose}}
+                  />
+                </:content>
+              </Item>
             {{/if}}
           </:left>
           <:right as |Item|>
@@ -216,7 +221,9 @@
                 <TrimInput
                   @width="block"
                   @value={{@model.structuredIdentifierSharepoint.localId}}
-                  @onUpdate={{fn (mut @model.structuredIdentifierSharepoint.localId)}}
+                  @onUpdate={{fn
+                    (mut @model.structuredIdentifierSharepoint.localId)
+                  }}
                   id="sharepoint-identifier"
                 />
               </:content>
@@ -248,7 +255,9 @@
                       <WorshipServiceMultipleSelect
                         @selected={{@model.administrativeUnitChangeset.subOrganizations}}
                         @onChange={{fn
-                          (mut @model.administrativeUnitChangeset.subOrganizations)
+                          (mut
+                            @model.administrativeUnitChangeset.subOrganizations
+                          )
                         }}
                         id="related-worship-service"
                       />
@@ -265,7 +274,9 @@
                       <CentralWorshipSelect
                         @selected={{@model.administrativeUnitChangeset.isSubOrganizationOf}}
                         @onChange={{fn
-                          (mut @model.administrativeUnitChangeset.isSubOrganizationOf)
+                          (mut
+                            @model.administrativeUnitChangeset.isSubOrganizationOf
+                          )
                         }}
                         @error={{hasError}}
                         @id="related-central-worship-service"
@@ -283,7 +294,9 @@
                     <RepresentativeBodySelect
                       @selected={{@model.administrativeUnitChangeset.isAssociatedWith}}
                       @onChange={{fn
-                        (mut @model.administrativeUnitChangeset.isAssociatedWith)
+                        (mut
+                          @model.administrativeUnitChangeset.isAssociatedWith
+                        )
                       }}
                       @error={{hasError}}
                       @id="related-representative-body"
@@ -295,128 +308,142 @@
           {{else}}
             <Card.Columns>
               <:left as |Item|>
-              {{#if (or this.isNewOCMW this.isNewAgb this.isNewDistrict this.isNewIGS this.isNewPoliceZone this.isNewAssistanceZone)}}
-                <Item
-                  @labelFor="related-gemeente"
-                  @required={{(or this.isNewAgb this.isNewIGS this.isNewPoliceZone this.isNewAssistanceZone)}}
-                  @errorMessage={{@model.administrativeUnitChangeset.error.isSubOrganizationOf.validation}}
-                >
-                  <:label>Gemeente</:label>
-                  <:content as |hasError|>
-                    <AdministrativeUnitSelect
-                      @selected={{@model.administrativeUnitChangeset.isSubOrganizationOf}}
-                      @onChange={{this.setRelation}}
-                      @classificationCodes={{this.classificationCodes}}
-                      @error={{hasError}}
-                      @id="related-gemeente"
-                    />
-                  </:content>
-                </Item>
-
-                {{#if @model.administrativeUnitChangeset.isSubOrganizationOf}}
-                  <Item>
-                    <:label>
-                      Provincie
-                    </:label>
-                    <:content>
-                      {{@model.administrativeUnitChangeset.isSubOrganizationOf.isSubOrganizationOf.name}}
-                    </:content>
-                  </Item>
-                {{/if}}
-
-                {{#if this.isNewAgb}}
-                  <Item
-                    @labelFor="oprichting-gemeente"
-                    @required={{true}}
-                    @errorMessage={{@model.administrativeUnitChangeset.error.wasFoundedByOrganization.validation}}
-                  >
-                    <:label>Werd opgericht door</:label>
-                    <:content as |hasError|>
-                    <AdministrativeUnitSelect
-                      @disabled={{true}}
-                      @selected={{@model.administrativeUnitChangeset.wasFoundedByOrganization}}
-                      @onChange={{this.setRelation}}
-                      @classificationCodes={{this.classificationCodes}}
-                      @error={{hasError}}
-                      @id="oprichting-gemeente"
-                    />
-                    </:content>
-                  </Item>
-                {{/if}}
-
-                {{#if this.isNewIGS}}
-                  <Item
-                    @labelFor="has-participants"
-                    @required={{true}}
-                    @errorMessage={{@model.administrativeUnitChangeset.error.hasParticipants.validation}}
-                  >
-                    <:label>Heeft als participanten</:label>
-                    <:content as |hasError|>
-                    <AdministrativeUnitMultipleSelect
-                      @selected={{@model.administrativeUnitChangeset.hasParticipants}}
-                      @onChange={{this.setHasParticipants}}
-                      @classificationCodes={{this.classificationCodesIgsParticipants}}
-                      @error={{hasError}}
-                      @id="has-participants"
-                    />
-                    </:content>
-                  </Item>
-                {{/if}}
-              {{else}}
-                <Item
-                  @labelFor="related-provincie"
-                  @required={{this.isNewApb}}
-                  @errorMessage={{@model.administrativeUnitChangeset.error.isSubOrganizationOf.validation}}
-                >
-                  <:label>Provincie</:label>
-                  <:content as |hasError|>
-                    <ProvinceOrganizationSelect
-                      @selected={{@model.administrativeUnitChangeset.isSubOrganizationOf}}
-                      @onChange={{this.setRelation
-                      }}
-                      @error={{hasError}}
-                      @id="related-provincie"
-                    />
-                  </:content>
-                </Item>
-                {{#if this.isNewApb}}
+                {{#if
+                  (or
+                    this.isNewOCMW
+                    this.isNewAgb
+                    this.isNewDistrict
+                    this.isNewIGS
+                    this.isNewPoliceZone
+                    this.isNewAssistanceZone
+                  )
+                }}
                   <Item
                     @labelFor="related-gemeente"
-                    @required={{true}}
-                    @errorMessage={{@model.administrativeUnitChangeset.error.isAssociatedWith.validation}}
+                    @required={{(or
+                      this.isNewAgb
+                      this.isNewIGS
+                      this.isNewPoliceZone
+                      this.isNewAssistanceZone
+                    )}}
+                    @errorMessage={{@model.administrativeUnitChangeset.error.isSubOrganizationOf.validation}}
                   >
                     <:label>Gemeente</:label>
                     <:content as |hasError|>
                       <AdministrativeUnitSelect
-                        @selected={{@model.administrativeUnitChangeset.isAssociatedWith}}
-                        @onChange={{fn
-                          (mut @model.administrativeUnitChangeset.isAssociatedWith)
-                        }}
+                        @selected={{@model.administrativeUnitChangeset.isSubOrganizationOf}}
+                        @onChange={{this.setRelation}}
                         @classificationCodes={{this.classificationCodes}}
                         @error={{hasError}}
                         @id="related-gemeente"
                       />
                     </:content>
                   </Item>
+
+                  {{#if @model.administrativeUnitChangeset.isSubOrganizationOf}}
+                    <Item>
+                      <:label>
+                        Provincie
+                      </:label>
+                      <:content>
+                        {{@model.administrativeUnitChangeset.isSubOrganizationOf.isSubOrganizationOf.name}}
+                      </:content>
+                    </Item>
+                  {{/if}}
+
+                  {{#if this.isNewAgb}}
+                    <Item
+                      @labelFor="oprichting-gemeente"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnitChangeset.error.wasFoundedByOrganization.validation}}
+                    >
+                      <:label>Werd opgericht door</:label>
+                      <:content as |hasError|>
+                        <AdministrativeUnitSelect
+                          @disabled={{true}}
+                          @selected={{@model.administrativeUnitChangeset.wasFoundedByOrganization}}
+                          @onChange={{this.setRelation}}
+                          @classificationCodes={{this.classificationCodes}}
+                          @error={{hasError}}
+                          @id="oprichting-gemeente"
+                        />
+                      </:content>
+                    </Item>
+                  {{/if}}
+
+                  {{#if this.isNewIGS}}
+                    <Item
+                      @labelFor="has-participants"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnitChangeset.error.hasParticipants.validation}}
+                    >
+                      <:label>Heeft als participanten</:label>
+                      <:content as |hasError|>
+                        <AdministrativeUnitMultipleSelect
+                          @selected={{@model.administrativeUnitChangeset.hasParticipants}}
+                          @onChange={{this.setHasParticipants}}
+                          @classificationCodes={{this.classificationCodesIgsParticipants}}
+                          @error={{hasError}}
+                          @id="has-participants"
+                        />
+                      </:content>
+                    </Item>
+                  {{/if}}
+                {{else}}
                   <Item
-                    @labelFor="opregicht-provincie"
-                    @required={{true}}
-                    @errorMessage={{@model.administrativeUnitChangeset.error.wasFoundedByOrganization.validation}}
+                    @labelFor="related-provincie"
+                    @required={{this.isNewApb}}
+                    @errorMessage={{@model.administrativeUnitChangeset.error.isSubOrganizationOf.validation}}
                   >
-                    <:label>Werd opgericht door</:label>
+                    <:label>Provincie</:label>
                     <:content as |hasError|>
                       <ProvinceOrganizationSelect
-                      @disabled={{true}}
-                        @selected={{@model.administrativeUnitChangeset.wasFoundedByOrganization}}
-                        @onChange={{this.setRelation
-                        }}
+                        @selected={{@model.administrativeUnitChangeset.isSubOrganizationOf}}
+                        @onChange={{this.setRelation}}
                         @error={{hasError}}
-                        @id="opregicht-provincie"
+                        @id="related-provincie"
                       />
                     </:content>
                   </Item>
+                  {{#if this.isNewApb}}
+                    <Item
+                      @labelFor="related-gemeente"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnitChangeset.error.isAssociatedWith.validation}}
+                    >
+                      <:label>Gemeente</:label>
+                      <:content as |hasError|>
+                        <AdministrativeUnitSelect
+                          @selected={{@model.administrativeUnitChangeset.isAssociatedWith}}
+                          @onChange={{fn
+                            (mut
+                              @model.administrativeUnitChangeset.isAssociatedWith
+                            )
+                          }}
+                          @classificationCodes={{this.classificationCodes}}
+                          @error={{hasError}}
+                          @id="related-gemeente"
+                        />
+                      </:content>
+                    </Item>
+                    <Item
+                      @labelFor="opregicht-provincie"
+                      @required={{true}}
+                      @errorMessage={{@model.administrativeUnitChangeset.error.wasFoundedByOrganization.validation}}
+                    >
+                      <:label>Werd opgericht door</:label>
+                      <:content as |hasError|>
+                        <ProvinceOrganizationSelect
+                          @disabled={{true}}
+                          @selected={{@model.administrativeUnitChangeset.wasFoundedByOrganization}}
+                          @onChange={{this.setRelation}}
+                          @error={{hasError}}
+                          @id="opregicht-provincie"
+                        />
+                      </:content>
+                    </Item>
+                  {{/if}}
                 {{/if}}
-              {{/if}}
               </:left>
             </Card.Columns>
           {{/if}}


### PR DESCRIPTION
OP-2661

Some pointers on which changes are relevant:

- Templates
   - Added a new component `Error::Save`, typically right under the `AuButtonGroup`
   - Where necessary configured right alignment for the buttons and/or the message(s) shown underneath.
 - Controllers
   - Added a getter `hasValidationErrors` used to determine whether or not to show the overall error message. The body of this getter is derived from the if-condition in the `save` (or similar) function in the same controller.
- Other changes are purely formatting performed by an (overly) eager local instance of prettier.

Note that I only modified pages with forms that are currently accessible to users to avoid introducing bugs that might remain unnoticed for a long time. Most forms for adding and/or editing persons (and their positions) are not used as this information is synchronized from elsewhere.