### PR TITLE
Fix: use only alphanumeric characters to match identifiers

### DIFF
--- a/app/components/administrative-unit-select-by-identifier.hbs
+++ b/app/components/administrative-unit-select-by-identifier.hbs
@@ -11,6 +11,6 @@
     @triggerId={{@id}}
     as |identifier|
   >
-    {{format-identifier identifier}}
+    {{identifier}}
   </PowerSelect>
 </div>

--- a/app/components/administrative-unit-select-by-identifier.js
+++ b/app/components/administrative-unit-select-by-identifier.js
@@ -15,8 +15,11 @@ export default class AdministrativeUnitSelectByIdentifierComponent extends Compo
     searchParams = formatIdentifier([searchParams]);
 
     if (searchParams.trim() !== '') {
-      // Note: toLowerCase is needed to properly match OVO numbers
-      filter[`:prefix:identifier`] = searchParams.toLowerCase();
+      // Notes:
+      // - toLowerCase is needed to properly match OVO numbers
+      // - use index field that only contains alphanumeric characters
+      //   (cf. mu-search configuration)
+      filter[`:prefix:identifier.index`] = searchParams.toLowerCase();
     }
 
     filter['classification_id'] = getClassificationIds(
@@ -36,7 +39,9 @@ export default class AdministrativeUnitSelectByIdentifierComponent extends Compo
         // which does not result in array being returned
         if (Array.isArray(entry)) {
           return entry.filter((id) =>
-            id.toLowerCase().startsWith(searchParams.toLowerCase())
+            formatIdentifier([id.toLowerCase()]).startsWith(
+              searchParams.toLowerCase()
+            )
           );
         } else {
           return entry;

--- a/app/helpers/format-identifier.js
+++ b/app/helpers/format-identifier.js
@@ -1,7 +1,7 @@
 import { helper } from '@ember/component/helper';
 
 export function formatIdentifier([identifier]) {
-  return identifier.replace(/[^\w]/gi, '');
+  return identifier.replace(/[^a-zA-Z0-9]/gi, '');
 }
 
 export default helper(formatIdentifier);

--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -39,8 +39,13 @@ export default class AdministrativeUnitsIndexRoute extends Route {
     }
 
     if (params.identifier) {
-      // Note: toLowerCase is needed to properly match OVO numbers
-      filter[':prefix:identifier'] = params.identifier.toLowerCase().trim();
+      // Notes:
+      // - toLowerCase is needed to properly match OVO numbers
+      // - use index field that only contains alphanumeric characters
+      //   (cf. mu-search configuration)
+      filter[':prefix:identifier.index'] = params.identifier
+        .toLowerCase()
+        .trim();
     }
 
     if (params.classificationId) {


### PR DESCRIPTION
OP-2725

Changes to match identifiers based only on their alphanumeric characters using a new `index` field introduced in the backend.
The previous PR including underscores as allowed input was still buggy for identifiers containing other non-alphanumeric characters such as dashes and brackets.