### PR TITLE
Add timeout when loading site types

### DIFF
--- a/app/components/site-type-select.js
+++ b/app/components/site-type-select.js
@@ -1,6 +1,6 @@
 import Component from '@glimmer/component';
 import { inject as service } from '@ember/service';
-import { task } from 'ember-concurrency';
+import { task, timeout } from 'ember-concurrency';
 import { CLASSIFICATION_CODE } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 
 export default class SiteTypeSelectComponent extends Component {
@@ -80,6 +80,8 @@ export default class SiteTypeSelectComponent extends Component {
 
   @task
   *loadSiteTypesTask() {
+    yield timeout(500);
+
     let allTypes = yield this.store.findAll('site-type', { reload: true });
     let filteredTypes = [];
 


### PR DESCRIPTION
OP-2777

Seems like the issue was that the loading was sometimes called before the getters could fully resolve the model, causing in those situations the filtering of the types to not be working as expected. Adding a small timeout prevents it.