### PR TITLE
Fix selected province and municipality in core data related orgs

### DIFF
--- a/app/components/province-organization-select.hbs
+++ b/app/components/province-organization-select.hbs
@@ -6,6 +6,7 @@
     @loadingMessage="Aan het laden..."
     @noMatchesMessage="Geen resultaten"
     @searchMessage="Typ om te zoeken"
+    @searchField="name"
     @options={{this.provinces.value}}
     @selected={{@selected}}
     @onChange={{@onChange}}

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -5,12 +5,9 @@ import { combineFullAddress } from 'frontend-organization-portal/models/address'
 import { action } from '@ember/object';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
 import { CLASSIFICATION_CODE } from 'frontend-organization-portal/models/administrative-unit-classification-code';
-import { tracked } from '@glimmer/tracking';
 
 export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController extends Controller {
   @service router;
-  @tracked selectedMunicipality;
-  @tracked selectedProvince;
 
   get hasValidationErrors() {
     return (
@@ -125,8 +122,6 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
 
     if (this.isAgb || this.isApb)
       this.model.administrativeUnit.wasFoundedByOrganization = unit;
-
-    this.selectedProvince = unit;
   }
 
   @action
@@ -137,9 +132,6 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
   @action
   setMunicipality(municipality) {
     this.model.administrativeUnit.isAssociatedWith = municipality;
-    this.selectedMunicipality = municipality;
-
-    return this.selectedMunicipality;
   }
 
   @dropTask

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -389,7 +389,7 @@
                             @selected={{@model.administrativeUnit.isSubOrganizationOf}}
                             @onChange={{this.setRelation}}
                             @allowClear={{(not @model.administrativeUnit.isAssociatedWith)}}
-                            @selectedMunicipality={{this.selectedMunicipality}}
+                            @selectedMunicipality={{@model.administrativeUnit.isAssociatedWith}}
                             @error={{hasError}}
                             @id="related-provincie"
                           />
@@ -406,7 +406,7 @@
                           @selected={{@model.administrativeUnit.isAssociatedWith}}
                           @onChange={{this.setMunicipality}}
                           @allowClear={{true}}
-                          @selectedProvince={{this.selectedProvince}}
+                          @selectedProvince={{@model.administrativeUnit.wasFoundedByOrganization}}
                           @classificationCodes={{this.classificationCodes}}
                           @error={{hasError}}
                           @id="related-gemeente"


### PR DESCRIPTION
OP-2788

On first load or after a refresh, `this.selectedProvince` and `this.selectedMunicipality` were not set, causing the conditional selection not to work.