### PR TITLE
Avoid scrolling in multiple select on classifcation

### DIFF
--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -204,6 +204,6 @@ $ember-power-select-focus-outline: solid 2px rgb(16, 108, 200) !default;
   }
 }
 
-#classification .ember-power-select-multiple-options {
+.ember-power-select-multiple-options {
   max-height: none;
 }

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -203,3 +203,7 @@ $ember-power-select-focus-outline: solid 2px rgb(16, 108, 200) !default;
     }
   }
 }
+
+.ember-power-select-multiple-options {
+  max-height: none;
+}

--- a/app/styles/_shame.scss
+++ b/app/styles/_shame.scss
@@ -204,6 +204,6 @@ $ember-power-select-focus-outline: solid 2px rgb(16, 108, 200) !default;
   }
 }
 
-.ember-power-select-multiple-options {
+#classification .ember-power-select-multiple-options {
   max-height: none;
 }


### PR DESCRIPTION
So this is related to OP-2854, the line avoiding the power select to go full height was defined in appuniversum, as it was set to a max-width of 10rem, I assumed this is something we only want to do in the classification power select, so I restricted it to only be there, but if you think we want this behaviour on all the multiple power select I can change it