### PR TITLE
Add feature flag service and helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,62 @@ Specify what it takes to deploy your app.
 ## Docker
 
 Build the image: docker build -t lblod/frontend-organization-portal -f Dockerfile.fastboot .
+
+## Reference
+
+### Feature flags
+
+Feature flags are used to enable/disable features in the application. They are defined in [config/environment.js](config/environment.js).
+
+```javascript
+// in config/environment.js
+let ENV = {
+  // Other configuration settings...
+  features: {
+    "new-feature": true, // Enable the 'new-feature' by default
+    "beta-feature": false, // Disable the 'beta-feature' by default
+  },
+};
+```
+
+The configuration can be manually overridden by adding a query parameter to the URL:
+
+- `?feature-new-feature=false` to disable the 'new-feature'
+- `?feature-beta-feature=true` to enable the 'beta-feature'
+
+The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding `?clear-feature-overrides=true` to the URL.
+
+The feature flags can be used in the application by injecting the `features` service and calling the `isEnabled` method.
+
+```javascript
+import { inject as service } from "@ember/service";
+
+export default class ExampleComponent extends Component {
+  @service features;
+
+  doSomething() {
+    if (this.features.isEnabled("new-feature")) {
+      // Implement the logic for the new feature
+      console.log("New feature is enabled!");
+    } else {
+      // Implement the logic for the default behavior without the new feature
+      console.log("New feature is disabled!");
+    }
+  }
+}
+```
+
+Or in template files by using the `is-feature-enabled` helper:
+
+```handlebars
+{{#if (is-feature-enabled "new-feature")}}
+  <p>New feature is enabled!</p>
+{{else}}
+  <p>New feature is disabled!</p>
+{{/if}}
+```
+
+### List of feature flags
+
+| Name | Description |
+| ---- | ----------- |

--- a/app/helpers/is-feature-enabled.js
+++ b/app/helpers/is-feature-enabled.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+import { assert } from '@ember/debug';
+import { inject as service } from '@ember/service';
+
+export default class IsFeatureEnabledHelper extends Helper {
+  @service features;
+
+  compute(positional) {
+    assert(
+      'is-feature-enabled expects exactly one argument',
+      positional.length === 1
+    );
+
+    return this.features.isEnabled(positional[0] || '');
+  }
+}

--- a/app/services/features.js
+++ b/app/services/features.js
@@ -1,0 +1,109 @@
+import Service from '@ember/service';
+import { assert } from '@ember/debug';
+import config from 'frontend-organization-portal/config/environment';
+
+export default class FeaturesService extends Service {
+  static PREFIX = 'feature-';
+  #features = {};
+
+  constructor() {
+    super();
+    const queryParams = this.#getQueryParams();
+    if (queryParams.get('clear-feature-overrides') === 'true') {
+      this.#clearCookieFeatures();
+    }
+
+    const configFeatures = this.#getConfigFeatures();
+    const cookieFeatures = this.#getCookieFeatures();
+    const queryFeatures = this.#getQueryParamsFeatures(queryParams);
+    this.setup({
+      ...configFeatures,
+      ...cookieFeatures,
+      ...queryFeatures,
+    });
+
+    // save query params in cookie
+    if (Object.keys(queryFeatures).length > 0) {
+      this.#setCookieFeatures(queryFeatures);
+    }
+  }
+
+  setup(features) {
+    this.#features = { ...features };
+    console.log('Feature flags:', this.#features);
+  }
+
+  isEnabled(feature) {
+    assert(
+      `The "${feature}" feature is not defined. Make sure the feature is defined in the "features" object in the config/environment.js file and that there are no typos in the name.`,
+      feature in this.#features
+    );
+
+    return this.#features[feature] ?? false;
+  }
+
+  #getConfigFeatures() {
+    const configFeatures = Object.fromEntries(
+      Object.entries(config.features).map(([featureName, value]) => {
+        return [featureName, value === 'true' || value === true];
+      })
+    );
+
+    return configFeatures;
+  }
+
+  // cookie has to start with 'feature-{{feature-name}}'
+  #getCookieFeatures() {
+    const cookieFeatures = {};
+    const cookies = document.cookie.split('; ');
+
+    for (const cookie of cookies) {
+      const [key, value] = cookie.split('=');
+      const featureName = this.#extractFeatureNameFromKey(key);
+      if (featureName) {
+        cookieFeatures[featureName] = value === 'true';
+      }
+    }
+
+    return cookieFeatures;
+  }
+
+  #setCookieFeatures(features) {
+    for (const [featureName, featureValue] of Object.entries(features)) {
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=${featureValue}; path=/`;
+    }
+  }
+
+  #clearCookieFeatures() {
+    const featuresToClear = Object.keys(this.#getCookieFeatures());
+    for (const featureName of featuresToClear) {
+      document.cookie = `${FeaturesService.PREFIX}${featureName}=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+    }
+  }
+
+  #getQueryParams() {
+    const queryString = window.location.search.substring(1);
+    return new URLSearchParams(queryString);
+  }
+
+  //query param has to start with 'feature-{{feature-name}}'
+  #getQueryParamsFeatures(queryParams) {
+    const queryFeatures = {};
+
+    for (const [key, value] of queryParams.entries()) {
+      const featureName = this.#extractFeatureNameFromKey(key);
+      if (featureName) {
+        queryFeatures[featureName] = value === 'true';
+      }
+    }
+
+    return queryFeatures;
+  }
+
+  #extractFeatureNameFromKey(key) {
+    if (key?.startsWith(FeaturesService.PREFIX)) {
+      return key.replace(FeaturesService.PREFIX, '');
+    }
+    return null;
+  }
+}

--- a/config/environment.js
+++ b/config/environment.js
@@ -67,6 +67,10 @@ module.exports = function (environment) {
           'https://abb-vlaanderen.gitbook.io/handleiding-organisatieportaal/modules/personen',
       },
     },
+
+    features: {
+      // define feature flags here
+    },
   };
 
   if (environment === 'development') {

--- a/tests/unit/services/features-test.js
+++ b/tests/unit/services/features-test.js
@@ -1,0 +1,32 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | features', function (hooks) {
+  setupTest(hooks);
+
+  this.subject = function () {
+    return this.owner.lookup('service:features');
+  };
+
+  module('isEnabled', function () {
+    test('it returns true when the feature is enabled', function (assert) {
+      const features = this.subject();
+      features.setup({ test: true });
+
+      assert.true(features.isEnabled('test'));
+    });
+
+    test('it return false when the feature is disabled', function (assert) {
+      const features = this.subject();
+      features.setup({ test: false });
+
+      assert.false(features.isEnabled('test'));
+    });
+
+    test('it throws when the feature is not configured', function (assert) {
+      const features = this.subject();
+
+      assert.throws(() => features.isEnabled('test'));
+    });
+  });
+});


### PR DESCRIPTION
Import Feature flag service and helper from [Lokaal Beslist](https://github.com/lblod/frontend-burgernabije-besluitendatabank/tree/master#feature-flags). 

## How to use it? 

1. Define a new flag in the [config/environment.js](https://github.com/lblod/frontend-organization-portal/blob/master/config/environment.js)
```javascript
// in config/environment.js
let ENV = {
  // Other configuration settings...
  features: {
    "new-feature": true, // Enable the 'new-feature' by default
    "beta-feature": false, // Disable the 'beta-feature' by default
  },
};
```
2. Wrap your modifications behind the flag : 

With the service in router/controller/components
```javascript
import { inject as service } from "@ember/service";

export default class ExampleComponent extends Component {
  @service features;

  doSomething() {
    if (this.features.isEnabled("new-feature")) {
      // Implement the logic for the new feature
      console.log("New feature is enabled!");
    } else {
      // Implement the logic for the default behavior without the new feature
      console.log("New feature is disabled!");
    }
  }
}
```
With the helper in template
```handlebars
{{#if (is-feature-enabled "new-feature")}}
  <p>New feature is enabled!</p>
{{else}}
  <p>New feature is disabled!</p>
{{/if}}
```

## How to test? 
The default flag value in configuration can be manually overridden by adding a query parameter to the URL:

- `?feature-new-feature=false` to disable the 'new-feature'
- `?feature-beta-feature=true` to enable the 'beta-feature'

The overriding will be saved in a cookie, so it will persist across page reloads. The cookie can be cleared by adding `?clear-feature-overrides=true` to the URL or manually remove the cookie in developer tools. 