### PR TITLE
Use identifier instead of structuredIdentifier to detect error

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -19,8 +19,8 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
       this.model.address.error ||
       this.model.contact.error ||
       this.model.secondaryContact.error ||
-      this.model.structuredIdentifierKBO.error ||
-      this.model.structuredIdentifierSharepoint.error
+      this.model.identifierKBO.error ||
+      this.model.identifierSharepoint.error
     );
   }
 

--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -22,8 +22,8 @@ export default class AdministrativeUnitsNewController extends Controller {
       this.model.address.error ||
       this.model.contact.error ||
       this.model.secondaryContact.error ||
-      this.model.structuredIdentifierKBO.error ||
-      this.model.structuredIdentifierSharepoint.error
+      this.model.identifierKBO.error ||
+      this.model.identifierSharepoint.error
     );
   }
 


### PR DESCRIPTION
In https://github.com/lblod/frontend-organization-portal/pull/554 we move validation to `identifier` instead of `structuredIdentifier`. `hasValidationErrors` in controller needed to be updated also in order to prevent form submission when `identifierKBO` or `identifierSharepoint` is wrong.