### PR TITLE
Fix reseting controller when exiting `administrative-units.administrative-unit.core-data.edit`

### DIFF
--- a/app/routes/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/routes/administrative-units/administrative-unit/core-data/edit.js
@@ -11,6 +11,8 @@ import { ID_NAME } from 'frontend-organization-portal/models/identifier';
 import { A } from '@ember/array';
 import { CLASSIFICATION_CODE } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 
+import { action } from '@ember/object';
+
 export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute extends Route {
   @service store;
   @service currentSession;
@@ -22,6 +24,14 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute exte
         wildcard: 'pagina-niet-gevonden',
       });
     }
+  }
+
+  @action
+  willTransition() {
+    // controller needs to be reset before index model hook is called
+    // willTransition is the first hook called when transitioning to another route
+    // eslint-disable-next-line ember/no-controller-access-in-routes
+    this.controller.reset();
   }
 
   async model() {
@@ -133,10 +143,5 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute exte
 
       return missingIdentifiers;
     }, []);
-  }
-
-  resetController(controller) {
-    super.resetController(...arguments);
-    controller.reset();
   }
 }


### PR DESCRIPTION
Related to OP-2814

https://github.com/lblod/frontend-organization-portal/pull/554 introduces a bug when we exiting edit route. Model changes in /edit are not undone before calling the /index `model` hook, this may cause errors. 

## To reproduce
- Edit an administrative unit
- Switch to manual address `Vul adres manueel in`
- Remove municipality
- cancel edition by clicking on `Annuleer`

You are redirected to `/pagina-niet-gevonden` due to error (`TypeError: municipalityUnit is undefined`
) in route `administrative-units.administrative-unit.core-data.index` `model` hook. 

## Proposal to fix

Move `controller.reset()`, that undo all model changes, in `administrative-units.administrative-unit.core-data.edit` `willTransition` hook instead of `resetController`. 

Clicking on the `Annuleer` button will initiate transition from /edit to /index, route hooks are called in the following order:
1. /edit `willTransition`
2. /index `model`
3. /edit `resetController`
4. /edit `deactivate`