### PR TITLE
Fix AGB/APB edit form validation

### DIFF
--- a/app/routes/administrative-units/administrative-unit/core-data.js
+++ b/app/routes/administrative-units/administrative-unit/core-data.js
@@ -20,6 +20,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataRoute extends 
         'is-sub-organization-of',
         'is-associated-with',
         'resulted-from',
+        'was-founded-by-organizations',
       ].join(),
     });
   }


### PR DESCRIPTION
Related to OP-2937

## Context
`wasFoundedByOrganizations` is a required field by some forms like AGB or APB. 
https://github.com/lblod/frontend-organization-portal/blob/c4283ee4a7a2d46672e7e079c47732a02c0b17da/app/models/administrative-unit.js#L79-L87
Because `wasFoundedByOrganizations` is not directly used in the form, except when editing the relation. https://github.com/lblod/frontend-organization-portal/blob/c4283ee4a7a2d46672e7e079c47732a02c0b17da/app/controllers/administrative-units/administrative-unit/core-data/edit.js#L77-L98
The value of `wasFoundedByOrganizations` is not available the first validate call, then return an error. 

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/73e9a05a-2daa-461b-9b90-392d44266748)

## Proposal

Force loading `wasFoundedByOrganizations` by adding it in the require field when the `administrative-unit` is loaded. 