### PR TITLE
Fix administrative-unit edit validtion on WorshipService

### DIFF
--- a/app/models/worship-service.js
+++ b/app/models/worship-service.js
@@ -1,5 +1,6 @@
 import { attr } from '@ember-data/model';
 import WorshipAdministrativeUnitModel from './worship-administrative-unit';
+import Joi from 'joi';
 
 export default class WorshipServiceModel extends WorshipAdministrativeUnitModel {
   @attr denomination;
@@ -11,5 +12,12 @@ export default class WorshipServiceModel extends WorshipAdministrativeUnitModel 
     } else {
       return 'Nee';
     }
+  }
+
+  get validationSchema() {
+    return super.validationSchema.append({
+      denomination: Joi.string().empty(''),
+      crossBorder: Joi.boolean(),
+    });
   }
 }


### PR DESCRIPTION
## Context

`mu-cl-resources` returns the most specific type. For example, when you request an `adminstrative-unit`, you can receive in response a `worship-service`. It's the case when you want edit a `Bestuur van de eredienst`. 

In that case, when you submit the edit form, you get an error message because the model contains more properties than the `administrative-unit` validationSchema accept. 

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/ba5dbb7d-d0ff-4924-8584-65ed9b3e911d)

## Proposal

Add `validationSchema` on `WorshipServiceModel`. 