### PR TITLE
Fix: show related organisations in edit core data form for PEVAs

### DIFF
--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -318,6 +318,8 @@
               @model.administrativeUnit.isPoliceZone
               @model.administrativeUnit.isAssistanceZone
               @model.administrativeUnit.isOcmwAssociation
+              @model.administrativeUnit.isPevaMunicipality
+              @model.administrativeUnit.isPevaProvince
             )
           )
         }}
@@ -362,12 +364,7 @@
                       </Item>
                     {{/if}}
 
-                    {{#if
-                      (or
-                        @model.administrativeUnit.isAgb
-                        @model.administrativeUnit.isPevaMunicipality
-                      )
-                    }}
+                    {{#if @model.administrativeUnit.isAgb}}
                       <Item
                         @labelFor="oprichting-gemeente"
                         @required={{true}}


### PR DESCRIPTION
Related to OP-3047

The reported bug also revealed that the edit core data form contains insufficient fields in case the organisation being edited is a PEVA municipality or PEVA province. More specifically, the form lacks the related organizations part in such case. This PR corrects this particular form so that it shows the correct fields for both types of PEVAs. 

Note: this PR is **not** intended to fix the reported bug itself, i.e. the inability to edit core data of PEVAs that do not have a founding organisation.