### PR TITLE
Feat: add legal name for organisations

### DIFF
--- a/app/components/administrative-unit-multiple-select.hbs
+++ b/app/components/administrative-unit-multiple-select.hbs
@@ -13,7 +13,7 @@
     @triggerId={{@id}}
     as |administrativeUnit|
   >
-    {{administrativeUnit.name}}
+    {{administrativeUnit.abbName}}
     ({{administrativeUnit.classification.label}})
   </PowerSelectMultiple>
 </div>

--- a/app/components/administrative-unit-select-by-name.js
+++ b/app/components/administrative-unit-select-by-name.js
@@ -12,7 +12,7 @@ export default class AdministrativeUnitSelectByNameComponent extends Component {
     const filter = {};
 
     if (searchParams.trim() !== '') {
-      filter[`:phrase_prefix:name`] = searchParams;
+      filter[`:phrase_prefix:legal_name,name`] = searchParams;
     }
 
     filter['classification_id'] = getClassificationIds(

--- a/app/components/administrative-unit-select.hbs
+++ b/app/components/administrative-unit-select.hbs
@@ -12,7 +12,7 @@
     @selected={{this.selectedAdministrativeUnit}}
     as |administrativeUnit|
   >
-    {{administrativeUnit.name}}
+    {{administrativeUnit.abbName}}
 
     {{#if
       (and

--- a/app/components/central-worship-select.hbs
+++ b/app/components/central-worship-select.hbs
@@ -13,6 +13,6 @@
     @triggerId={{@id}}
     as |centralWorshipService|
   >
-    {{centralWorshipService.name}}
+    {{centralWorshipService.abbName}}
   </PowerSelect>
 </div>

--- a/app/components/error/kbo-number.hbs
+++ b/app/components/error/kbo-number.hbs
@@ -1,12 +1,12 @@
 <AuHelpText @error={{true}}>
   {{@error.message}}
   {{#if @error.context.administrativeUnit}}
-  <AuLink
-    @route="administrative-units.administrative-unit"
-    @model={{@error.context.administrativeUnit.id}}
-    target="_blank"
-  >
-    {{@error.context.administrativeUnit.name}}
-  </AuLink>
+    <AuLink
+      @route="administrative-units.administrative-unit"
+      @model={{@error.context.administrativeUnit.id}}
+      target="_blank"
+    >
+      {{@error.context.administrativeUnit.abbName}}
+    </AuLink>
   {{/if}}
 </AuHelpText>

--- a/app/components/municipality-select.hbs
+++ b/app/components/municipality-select.hbs
@@ -13,6 +13,6 @@
     @triggerId={{@id}}
     as |municipality|
   >
-    {{municipality.name}}
+    {{municipality.abbName}}
   </PowerSelect>
 </div>

--- a/app/components/province-organization-select.hbs
+++ b/app/components/province-organization-select.hbs
@@ -13,6 +13,6 @@
     @triggerId={{@id}}
     as |province|
   >
-    {{province.name}}
+    {{province.abbName}}
   </PowerSelect>
 </div>

--- a/app/components/related-organizations/edit-agb.hbs
+++ b/app/components/related-organizations/edit-agb.hbs
@@ -13,19 +13,15 @@
             <MunicipalitySelect
               @selected={{@model.administrativeUnit.isSubOrganizationOf}}
               @onChange={{@updateRelatedOrg}}
-
               @error={{hasError}}
               @id="related-gemeente"
             />
           </:content>
         </Item>
-        <Item
-          @labelFor="related-municipality"
-          @required={{true}}
-        >
+        <Item @labelFor="related-municipality" @required={{true}}>
           <:label>Provincie</:label>
           <:content>
-            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
           </:content>
         </Item>
       </:left>
@@ -38,26 +34,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft relatie met
     </AuHeading>
-    <AuDataTable id="subOrganizations" @content={{@model.subOrganizations}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="subOrganizations"
+      @content={{@model.subOrganizations}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |subOrganization|>
           <td>
             {{subOrganization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-              {{subOrganization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{subOrganization.id}}
+            >
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-              @label={{subOrganization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{subOrganization.organizationStatus.id}}
+              @label={{subOrganization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/edit-apb.hbs
+++ b/app/components/related-organizations/edit-apb.hbs
@@ -80,7 +80,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/edit-assistance-zone.hbs
+++ b/app/components/related-organizations/edit-assistance-zone.hbs
@@ -20,13 +20,10 @@
             />
           </:content>
         </Item>
-        <Item
-          @labelFor="related-municipality"
-          @required={{true}}
-        >
+        <Item @labelFor="related-municipality" @required={{true}}>
           <:label>Provincie</:label>
           <:content>
-            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
           </:content>
         </Item>
       </:left>

--- a/app/components/related-organizations/edit-igs.hbs
+++ b/app/components/related-organizations/edit-igs.hbs
@@ -23,7 +23,7 @@
         <Item @labelFor="related-municipality">
           <:label>Provincie</:label>
           <:content>
-            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
           </:content>
         </Item>
       </:left>
@@ -38,7 +38,9 @@
 
   {{#if @model.administrativeUnit.error.hasParticipants.message}}
     <div>
-      <AuHelpText @error={{true}}>{{@model.administrativeUnit.error.hasParticipants.message}}</AuHelpText>
+      <AuHelpText
+        @error={{true}}
+      >{{@model.administrativeUnit.error.hasParticipants.message}}</AuHelpText>
     </div>
   {{/if}}
 
@@ -78,10 +80,7 @@
             @icon="bin"
             @iconAlignment="left"
             @skin="link"
-            {{on
-              "click"
-              (fn @removeHasParticipants organization)
-            }}
+            {{on "click" (fn @removeHasParticipants organization)}}
           >
             Verwijder
           </AuButton>

--- a/app/components/related-organizations/edit-municipality.hbs
+++ b/app/components/related-organizations/edit-municipality.hbs
@@ -23,7 +23,7 @@
         <Item @labelFor="related-ocmw">
           <:label>OCMW</:label>
           <:content>
-            {{@model.administrativeUnit.isAssociatedWith.name}}
+            {{@model.administrativeUnit.isAssociatedWith.abbName}}
           </:content>
         </Item>
       </:left>
@@ -36,26 +36,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft relatie met
     </AuHeading>
-    <AuDataTable id="foundedOrganizations" @content={{@model.administrativeUnit.foundedOrganizations}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="foundedOrganizations"
+      @content={{@model.administrativeUnit.foundedOrganizations}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |subOrganization|>
           <td>
             {{subOrganization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-              {{subOrganization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{subOrganization.id}}
+            >
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-              @label={{subOrganization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{subOrganization.organizationStatus.id}}
+              @label={{subOrganization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/edit-ocmw-association.hbs
+++ b/app/components/related-organizations/edit-ocmw-association.hbs
@@ -108,7 +108,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/edit-ocmw.hbs
+++ b/app/components/related-organizations/edit-ocmw.hbs
@@ -23,7 +23,7 @@
         <Item>
           <:label>Gemeente</:label>
           <:content>
-            {{@model.administrativeUnit.isAssociatedWith.name}}
+            {{@model.administrativeUnit.isAssociatedWith.abbName}}
           </:content>
         </Item>
       </:left>

--- a/app/components/related-organizations/edit-peva-municipality.hbs
+++ b/app/components/related-organizations/edit-peva-municipality.hbs
@@ -108,7 +108,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/edit-peva-province.hbs
+++ b/app/components/related-organizations/edit-peva-province.hbs
@@ -108,7 +108,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/edit-police-zone.hbs
+++ b/app/components/related-organizations/edit-police-zone.hbs
@@ -20,13 +20,10 @@
             />
           </:content>
         </Item>
-        <Item
-          @labelFor="related-municipality"
-          @required={{true}}
-        >
+        <Item @labelFor="related-municipality" @required={{true}}>
           <:label>Provincie</:label>
           <:content>
-            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+            {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
           </:content>
         </Item>
       </:left>

--- a/app/components/related-organizations/view-agb.hbs
+++ b/app/components/related-organizations/view-agb.hbs
@@ -12,7 +12,7 @@
               @route="administrative-units.administrative-unit"
               @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}
             >
-              {{@model.isSubOrganizationOf.isSubOrganizationOf.name}}
+              {{@model.isSubOrganizationOf.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -23,7 +23,7 @@
               @route="administrative-units.administrative-unit.core-data"
               @model={{@model.isSubOrganizationOf.id}}
             >
-              {{@model.isSubOrganizationOf.name}}
+              {{@model.isSubOrganizationOf.abbNname}}
             </AuLink>
           </:content>
         </Item>
@@ -40,7 +40,7 @@
                   <AuLink
                     @route="administrative-units.administrative-unit.core-data"
                     @model={{@model.id}}
-                  >{{org.name}}</AuLink>
+                  >{{org.abbName}}</AuLink>
                 </Item>
               {{/each}}
             </AuList>
@@ -89,7 +89,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/view-apb.hbs
+++ b/app/components/related-organizations/view-apb.hbs
@@ -12,7 +12,7 @@
               @route="administrative-units.administrative-unit"
               @model={{@model.isSubOrganizationOf.id}}
             >
-              {{@model.isSubOrganizationOf.name}}
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -23,7 +23,7 @@
               @route="administrative-units.administrative-unit.core-data"
               @model={{@model.isAssociatedWith.id}}
             >
-              {{@model.isAssociatedWith.name}}
+              {{@model.isAssociatedWith.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -39,7 +39,7 @@
                   <AuLink
                     @route="administrative-units.administrative-unit.core-data"
                     @model={{@model.id}}
-                  >{{org.name}}</AuLink>
+                  >{{org.abbName}}</AuLink>
                 </Item>
               {{/each}}
             </AuList>

--- a/app/components/related-organizations/view-assistance-zone.hbs
+++ b/app/components/related-organizations/view-assistance-zone.hbs
@@ -8,16 +8,22 @@
             Provincie
           </:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
         <Item>
           <:label>Gemeente</:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit.core-data" @model={{@model.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit.core-data"
+              @model={{@model.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -31,26 +37,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Participeert in
     </AuHeading>
-    <AuDataTable id="participatesIn" @content={{@model.participatesIn}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="participatesIn"
+      @content={{@model.participatesIn}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-central-worship-service.hbs
+++ b/app/components/related-organizations/view-central-worship-service.hbs
@@ -14,12 +14,15 @@
   <:card as |Card|>
     <Card.Columns>
       <:left as |Item|>
-        {{#if @model.isAssociatedWith.name}}
+        {{#if @model.isAssociatedWith.abbName}}
           <Item>
             <:label>Representatief orgaan</:label>
             <:content>
-              <AuLink @route="organizations.organization.core-data" @model={{@model.isAssociatedWith.id}}>
-                {{@model.isAssociatedWith.name}}
+              <AuLink
+                @route="organizations.organization.core-data"
+                @model={{@model.isAssociatedWith.id}}
+              >
+                {{@model.isAssociatedWith.abbName}}
               </AuLink>
             </:content>
           </Item>
@@ -34,12 +37,14 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft relatie met
     </AuHeading>
-    <AuDataTable 
-      id="subOrganizations" 
+    <AuDataTable
+      id="subOrganizations"
       @content={{@model.subOrganizations}}
       @page={{@page}}
       @size={{@size}}
-      @noDataMessage="Geen bestuur" as |t|>
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.menu as |menu|>
         <menu.general>
           <div class="au-o-box">
@@ -52,22 +57,39 @@
       </t.menu>
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |subOrganization|>
           <td>
             {{subOrganization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-              {{subOrganization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{subOrganization.id}}
+            >
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-              @label={{subOrganization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{subOrganization.organizationStatus.id}}
+              @label={{subOrganization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-district.hbs
+++ b/app/components/related-organizations/view-district.hbs
@@ -3,14 +3,17 @@
   <:card as |Card|>
     <Card.Columns>
       <:left as |Item|>
-        {{#if @model.isSubOrganizationOf.name}}
+        {{#if @model.isSubOrganizationOf.abbName}}
           <Item>
             <:label>
               Gemeente
             </:label>
             <:content>
-              <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.id}}>
-                {{@model.isSubOrganizationOf.name}}
+              <AuLink
+                @route="administrative-units.administrative-unit"
+                @model={{@model.isSubOrganizationOf.id}}
+              >
+                {{@model.isSubOrganizationOf.abbName}}
               </AuLink>
             </:content>
           </Item>
@@ -21,16 +24,22 @@
               Provincie
             </:label>
             <:content>
-              <AuLink @route="administrative-units.administrative-unit" @model={{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.id}}>
-                {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+              <AuLink
+                @route="administrative-units.administrative-unit"
+                @model={{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.id}}
+              >
+                {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
               </AuLink>
             </:content>
           </Item>
           <Item>
             <:label>OCMW</:label>
             <:content>
-              <AuLink @route="administrative-units.administrative-unit" @model={{@model.administrativeUnit.isSubOrganizationOf.isAssociatedWith.id}}>
-                {{@model.administrativeUnit.isSubOrganizationOf.isAssociatedWith.name}}
+              <AuLink
+                @route="administrative-units.administrative-unit"
+                @model={{@model.administrativeUnit.isSubOrganizationOf.isAssociatedWith.id}}
+              >
+                {{@model.administrativeUnit.isSubOrganizationOf.isAssociatedWith.abbName}}
               </AuLink>
             </:content>
           </Item>

--- a/app/components/related-organizations/view-igs.hbs
+++ b/app/components/related-organizations/view-igs.hbs
@@ -8,16 +8,22 @@
             Provincie
           </:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
         <Item>
           <:label>Gemeente</:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit.core-data" @model={{@model.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit.core-data"
+              @model={{@model.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -31,26 +37,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Participeert in
     </AuHeading>
-    <AuDataTable id="participatesIn" @content={{@model.participatesIn}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="participatesIn"
+      @content={{@model.participatesIn}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>
@@ -63,26 +90,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft als participanten
     </AuHeading>
-    <AuDataTable id="hasParticipants" @content={{@model.hasParticipants}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="hasParticipants"
+      @content={{@model.hasParticipants}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-municipality.hbs
+++ b/app/components/related-organizations/view-municipality.hbs
@@ -8,16 +8,22 @@
             Provincie
           </:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{@model.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
         <Item>
           <:label>OCMW</:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit.core-data" @model={{@model.isAssociatedWith.id}}>
-              {{@model.isAssociatedWith.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit.core-data"
+              @model={{@model.isAssociatedWith.id}}
+            >
+              {{@model.isAssociatedWith.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -31,12 +37,14 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft relatie met
     </AuHeading>
-    <AuDataTable 
-      id="foundedOrganizations" 
+    <AuDataTable
+      id="foundedOrganizations"
       @content={{@model.administrativeUnit.foundedOrganizations}}
       @page={{@page}}
       @size={{@size}}
-      @noDataMessage="Geen bestuur" as |t|>
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.menu as |menu|>
         <menu.general>
           <div class="au-o-box">
@@ -49,22 +57,39 @@
       </t.menu>
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |subOrganization|>
           <td>
             {{subOrganization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-              {{subOrganization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{subOrganization.id}}
+            >
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-              @label={{subOrganization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{subOrganization.organizationStatus.id}}
+              @label={{subOrganization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>
@@ -80,25 +105,44 @@
     <AuDataTable
       id="participatesIn"
       @content={{@model.participatesIn}}
-      @noDataMessage="Geen bestuur" as |t|>
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-ocmw-association.hbs
+++ b/app/components/related-organizations/view-ocmw-association.hbs
@@ -35,7 +35,7 @@
             @route="administrative-units.administrative-unit"
             @model={{organization.id}}
           >
-            {{organization.name}}
+            {{organization.abbName}}
           </AuLink>
         </td>
         <td>
@@ -99,7 +99,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -152,7 +152,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -205,7 +205,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/view-ocmw.hbs
+++ b/app/components/related-organizations/view-ocmw.hbs
@@ -8,16 +8,22 @@
             Provincie
           </:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{@model.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
         <Item>
           <:label>Gemeente</:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit.core-data" @model={{@model.isAssociatedWith.id}}>
-              {{@model.isAssociatedWith.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit.core-data"
+              @model={{@model.isAssociatedWith.id}}
+            >
+              {{@model.isAssociatedWith.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -31,26 +37,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Participeert in
     </AuHeading>
-    <AuDataTable id="participatesIn" @content={{@model.participatesIn}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="participatesIn"
+      @content={{@model.participatesIn}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-peva-municipality.hbs
+++ b/app/components/related-organizations/view-peva-municipality.hbs
@@ -35,7 +35,7 @@
             @route="administrative-units.administrative-unit"
             @model={{organization.id}}
           >
-            {{organization.name}}
+            {{organization.abbName}}
           </AuLink>
         </td>
         <td>
@@ -99,7 +99,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -152,7 +152,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -205,7 +205,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/view-peva-province.hbs
+++ b/app/components/related-organizations/view-peva-province.hbs
@@ -35,7 +35,7 @@
             @route="administrative-units.administrative-unit"
             @model={{organization.id}}
           >
-            {{organization.name}}
+            {{organization.abbName}}
           </AuLink>
         </td>
         <td>
@@ -99,7 +99,7 @@
               @route="administrative-units.administrative-unit"
               @model={{subOrganization.id}}
             >
-              {{subOrganization.name}}
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -152,7 +152,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
@@ -205,7 +205,7 @@
               @route="administrative-units.administrative-unit"
               @model={{organization.id}}
             >
-              {{organization.name}}
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>

--- a/app/components/related-organizations/view-police-zone.hbs
+++ b/app/components/related-organizations/view-police-zone.hbs
@@ -8,16 +8,22 @@
             Provincie
           </:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{@model.isSubOrganizationOf.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
         <Item>
           <:label>Gemeente</:label>
           <:content>
-            <AuLink @route="administrative-units.administrative-unit.core-data" @model={{@model.isSubOrganizationOf.id}}>
-              {{@model.isSubOrganizationOf.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit.core-data"
+              @model={{@model.isSubOrganizationOf.id}}
+            >
+              {{@model.isSubOrganizationOf.abbName}}
             </AuLink>
           </:content>
         </Item>
@@ -31,26 +37,47 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Participeert in
     </AuHeading>
-    <AuDataTable id="participatesIn" @content={{@model.participatesIn}}
-      @noDataMessage="Geen bestuur" as |t|>
+    <AuDataTable
+      id="participatesIn"
+      @content={{@model.participatesIn}}
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |organization|>
           <td>
             {{organization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{organization.id}}>
-              {{organization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{organization.id}}
+            >
+              {{organization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{organization.organizationStatus.id}}
-              @label={{organization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{organization.organizationStatus.id}}
+              @label={{organization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-province.hbs
+++ b/app/components/related-organizations/view-province.hbs
@@ -3,12 +3,14 @@
     <AuHeading @level="3" @skin="5" class="au-u-margin-bottom-tiny">
       Heeft relatie met
     </AuHeading>
-    <AuDataTable 
-      id="foundedOrganizations" 
+    <AuDataTable
+      id="foundedOrganizations"
       @content={{@model.administrativeUnit.foundedOrganizations}}
       @page={{@page}}
       @size={{@size}}
-      @noDataMessage="Geen bestuur" as |t|>
+      @noDataMessage="Geen bestuur"
+      as |t|
+    >
       <t.menu as |menu|>
         <menu.general>
           <div class="au-o-box">
@@ -21,22 +23,39 @@
       </t.menu>
       <t.content as |c|>
         <c.header>
-          <AuDataTableThSortable @field="classification.label" @label="Type organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="name" @label="Organisatie" @currentSorting={{@sort}} />
-          <AuDataTableThSortable @field="organizationStatus.label" @label="Status" @currentSorting={{@sort}} />
+          <AuDataTableThSortable
+            @field="classification.label"
+            @label="Type organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="name"
+            @label="Organisatie"
+            @currentSorting={{@sort}}
+          />
+          <AuDataTableThSortable
+            @field="organizationStatus.label"
+            @label="Status"
+            @currentSorting={{@sort}}
+          />
         </c.header>
         <c.body as |subOrganization|>
           <td>
             {{subOrganization.classification.label}}
           </td>
           <td>
-            <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-              {{subOrganization.name}}
+            <AuLink
+              @route="administrative-units.administrative-unit"
+              @model={{subOrganization.id}}
+            >
+              {{subOrganization.abbName}}
             </AuLink>
           </td>
           <td>
-            <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-              @label={{subOrganization.organizationStatus.label}} />
+            <OrganizationStatus
+              @id={{subOrganization.organizationStatus.id}}
+              @label={{subOrganization.organizationStatus.label}}
+            />
           </td>
         </c.body>
       </t.content>

--- a/app/components/related-organizations/view-worship-service.hbs
+++ b/app/components/related-organizations/view-worship-service.hbs
@@ -14,12 +14,15 @@
   <:card as |Card|>
     <Card.Columns>
       <:left as |Item|>
-        {{#if @model.isAssociatedWith.name}}
+        {{#if @model.isAssociatedWith.abbName}}
           <Item>
             <:label>Representatief orgaan</:label>
             <:content>
-              <AuLink @route="organizations.organization.core-data" @model={{@model.isAssociatedWith.id}}>
-                {{@model.isAssociatedWith.name}}
+              <AuLink
+                @route="organizations.organization.core-data"
+                @model={{@model.isAssociatedWith.id}}
+              >
+                {{@model.isAssociatedWith.abbName}}
               </AuLink>
             </:content>
           </Item>
@@ -27,11 +30,14 @@
         {{#if @model.isSubOrganizationOf}}
           <Item>
             <:label>
-                Centraal bestuur
+              Centraal bestuur
             </:label>
             <:content>
-              <AuLink @route="administrative-units.administrative-unit" @model={{@model.isSubOrganizationOf.id}}>
-                {{@model.isSubOrganizationOf.name}}
+              <AuLink
+                @route="administrative-units.administrative-unit"
+                @model={{@model.isSubOrganizationOf.id}}
+              >
+                {{@model.isSubOrganizationOf.abbName}}
               </AuLink>
             </:content>
           </Item>

--- a/app/components/representative-body-select.hbs
+++ b/app/components/representative-body-select.hbs
@@ -12,6 +12,6 @@
     @triggerId={{@id}}
     as |representativeBody|
   >
-    {{representativeBody.name}}
+    {{representativeBody.abbName}}
   </PowerSelect>
 </div>

--- a/app/components/worship-service-multiple-select.hbs
+++ b/app/components/worship-service-multiple-select.hbs
@@ -12,5 +12,5 @@
   ...attributes
   as |worshipService|
 >
-  {{worshipService.name}}
+  {{worshipService.abbName}}
 </PowerSelectMultiple>

--- a/app/components/worship-service-select.hbs
+++ b/app/components/worship-service-select.hbs
@@ -11,5 +11,5 @@
   ...attributes
   as |worshipService|
 >
-  {{worshipService.name}}
+  {{worshipService.abbName}}
 </PowerSelect>

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -70,6 +70,11 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
   }
 
   @action
+  setNames(name) {
+    this.model.administrativeUnit.setAbbName(name);
+  }
+
+  @action
   setKbo(value) {
     this.model.structuredIdentifierKBO.localId = value;
   }
@@ -192,17 +197,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
       yield identifierSharepoint.save();
 
       administrativeUnit = setEmptyStringsToNull(administrativeUnit);
-      if (
-        this.model.administrativeUnit.isProvince ||
-        this.model.administrativeUnit.isMunicipality
-      ) {
-        // set province or municipality name to null as data are already in the shared graph
-        administrativeUnit.name = null;
-        yield administrativeUnit.save();
-        yield administrativeUnit.reload();
-      } else {
-        yield administrativeUnit.save();
-      }
+      yield administrativeUnit.save();
 
       const syncOvoNumberEndpoint = `/sync-ovo-number/${structuredIdentifierKBO.id}`;
       yield fetch(syncOvoNumberEndpoint, {

--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -94,6 +94,11 @@ export default class AdministrativeUnitsNewController extends Controller {
   }
 
   @action
+  setNames(name) {
+    this.model.administrativeUnit.setAbbName(name);
+  }
+
+  @action
   setHasParticipants(units) {
     this.model.administrativeUnit.hasParticipants = units;
   }
@@ -152,7 +157,6 @@ export default class AdministrativeUnitsNewController extends Controller {
       } else {
         newAdministrativeUnit = administrativeUnit;
       }
-      // Copy data entered in the frontend to the new admin unit
       copyAdministrativeUnitData(newAdministrativeUnit, administrativeUnit);
 
       structuredIdentifierKBO = setEmptyStringsToNull(structuredIdentifierKBO);

--- a/app/helpers/help-text.js
+++ b/app/helpers/help-text.js
@@ -8,6 +8,10 @@ const HELP_TEXT = {
   kbo: 'Formaat: 0123.456.789',
   url: 'Bijvoorbeeld: https://www.vlaanderen.be',
   email: 'Bijvoorbeeld: mail@adres.com',
+  abbName:
+    'De naam wordt automatisch ingevuld. Deze naam is gelijk aan de juridische naam. Indien geen juridische naam beschikbaar is, wordt de naam uit KBO ingevuld.',
+  legalName:
+    'De juridische naam is de naam uit de statuten, decreet of andere juridisch regelgevende teksten of besluiten. Bij het aanmaken van de organisatie wordt deze ingegeven door ABB, daarna verhuist het beheer van deze naam naar de organisatie zelf, via de Contact app.',
 };
 
 export default helper(function helpText([key]) {

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -10,6 +10,7 @@ import {
 
 export default class OrganizationModel extends AgentModel {
   @attr name;
+  @attr legalName;
   @attr alternativeName;
   @attr('date') expectedEndDate;
   @attr purpose;
@@ -134,8 +135,9 @@ export default class OrganizationModel extends AgentModel {
 
   get validationSchema() {
     return super.validationSchema.append({
-      name: Joi.string().empty('').required().messages({
-        'any.required': 'Vul de naam in',
+      name: validateStringOptional(),
+      legalName: Joi.string().empty('').required().messages({
+        'any.required': 'Vul de juridische naam in',
       }),
       alternativeName: validateStringOptional(),
       expectedEndDate: Joi.date().allow(null),
@@ -157,5 +159,15 @@ export default class OrganizationModel extends AgentModel {
       participatesIn: validateHasManyOptional(),
       hasParticipants: validateHasManyOptional(),
     });
+  }
+
+  // TODO: use registered KBO name as fallback
+  get abbName() {
+    return this.legalName ?? this.name;
+  }
+
+  setAbbName(name) {
+    this.name = name;
+    this.legalName = name;
   }
 }

--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -36,7 +36,7 @@ export default class AdministrativeUnitsIndexRoute extends Route {
       let filterType = 'phrase_prefix';
       let name = params.name.trim();
 
-      filter[`:${filterType}:name`] = name;
+      filter[`:${filterType}:legal_name,name`] = name;
     }
 
     if (params.identifier) {

--- a/app/templates/administrative-units/administrative-unit.hbs
+++ b/app/templates/administrative-units/administrative-unit.hbs
@@ -1,6 +1,6 @@
-{{page-title this.model.name}}
+{{page-title this.model.abbName}}
 {{breadcrumb
-  this.model.name
+  this.model.abbName
   route="administrative-units.administrative-unit"
   model=this.model.id
 }}

--- a/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
@@ -15,7 +15,7 @@
         Bewerk veranderingsgebeurtenis:
         {{@model.changeEvent.type.label}}
       </:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <div class="au-u-text-right">
@@ -152,7 +152,7 @@
                 <Item>
                   <:label>Betrokken organisatie</:label>
                   <:content>
-                    {{organization.name}}
+                    {{organization.abbName}}
                   </:content>
                 </Item>
               {{/each}}

--- a/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
@@ -5,7 +5,7 @@
         Veranderingsgebeurtenis:
         {{@model.changeEvent.type.label}}
       </:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <SecuredArea>
@@ -112,7 +112,7 @@
                       @route="administrative-units.administrative-unit"
                       @model={{organization.id}}
                     >
-                      {{organization.name}}
+                      {{organization.abbName}}
                     </AuLink>
                   </:content>
                 </Item>

--- a/app/templates/administrative-units/administrative-unit/change-events/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/index.hbs
@@ -1,6 +1,7 @@
 <PageHeader class="au-o-box">
   <:title>Veranderingsgebeurtenissen</:title>
-  <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+  <:subtitle>{{@model.administrativeUnit.abbName}}
+    ({{@model.administrativeUnit.classification.label}})</:subtitle>
   <:action>
     <SecuredArea>
       <:edit>
@@ -62,11 +63,14 @@
           </AuLink>
         </td>
         <td>
-            {{date-format changeEvent.date}}
+          {{date-format changeEvent.date}}
         </td>
         <td>{{changeEvent.description}}</td>
         <td>
-          <OrganizationStatus @id={{changeEventResult.status.id}} @label={{changeEventResult.status.label}}/>
+          <OrganizationStatus
+            @id={{changeEventResult.status.id}}
+            @label={{changeEventResult.status.label}}
+          />
         </td>
         <SecuredArea>
           <:edit>

--- a/app/templates/administrative-units/administrative-unit/change-events/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/new.hbs
@@ -12,7 +12,7 @@
   >
     <PageHeader>
       <:title>Voeg veranderingsgebeurtenis toe</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <div class="au-u-text-right">
@@ -310,7 +310,7 @@
                           @onChange={{this.updateResultingOrganizations}}
                           as |organization|
                         >
-                          {{organization.name}}
+                          {{organization.abbName}}
                         </PowerSelect>
                       </div>
                     {{/if}}

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-box">
     <PageHeader class="au-u-margin-bottom-large">
       <:title>Bewerk kerngegevens</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <div class="au-u-text-right">
@@ -40,35 +40,45 @@
             <Card.Columns>
               <:left as |Item|>
                 <Item
-                  @labelFor="worship-service-name"
+                  @labelFor="administrative-unit-abb-name"
                   @required={{true}}
-                  @errorMessage={{@model.administrativeUnit.error.name.message}}
                 >
                   <:label>Naam</:label>
                   <:content as |hasError|>
                     <TrimInput
                       @width="block"
-                      @disabled={{or
-                        @model.administrativeUnit.isProvince
-                        @model.administrativeUnit.isMunicipality
-                      }}
-                      @value={{@model.administrativeUnit.name}}
+                      @disabled={{true}}
+                      @value={{@model.administrativeUnit.abbName}}
                       @onUpdate={{fn (mut @model.administrativeUnit.name)}}
                       @error={{hasError}}
-                      id="worship-service-name"
+                      id="administrative-unit-abb-name"
                     />
-                    {{#if
-                      (or
-                        @model.administrativeUnit.isProvince
+                    <AuHelpText>
+                      {{help-text "abbName"}}
+                    </AuHelpText>
+                  </:content>
+                </Item>
+                <Item
+                  @labelFor="administrative-unit-legal-name"
+                  @required={{true}}
+                  @errorMessage={{@model.administrativeUnit.error.legalName.message}}
+                >
+                  <:label>Juridische naam</:label>
+                  <:content as |hasError|>
+                    <TrimInput
+                      @width="block"
+                      @disabled={{(or
                         @model.administrativeUnit.isMunicipality
-                      )
-                    }}
-                      <AuHelpText>
-                        De naam van een gemeente en provincie kan voorlopig niet
-                        langer aangepast worden. Indien toch een aanpassing
-                        nodig, gelieve deze via de helpdesk aan te vragen.
-                      </AuHelpText>
-                    {{/if}}
+                        @model.administrativeUnit.isProvince
+                      )}}
+                      @value={{@model.administrativeUnit.legalName}}
+                      @onUpdate={{this.setNames}}
+                      @error={{hasError}}
+                      id="administrative-unit-legal-name"
+                    />
+                    <AuHelpText>
+                      {{help-text "legalName"}}
+                    </AuHelpText>
                   </:content>
                 </Item>
                 <Item @labelFor="classification">
@@ -359,7 +369,7 @@
                           Provincie
                         </:label>
                         <:content>
-                          {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+                          {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
                         </:content>
                       </Item>
                     {{/if}}

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -2,85 +2,350 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Kerngegevens</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
-      {{#if (is-feature-enabled "kbo-data-tab")}}
-        {{#if this.showAbbData}}
+        {{#if (is-feature-enabled "kbo-data-tab")}}
+          {{#if this.showAbbData}}
+            <SecuredArea>
+              <:edit>
+                <div class="au-u-flex--column">
+                  <AuLink
+                    @route="administrative-units.administrative-unit.core-data.edit"
+                    @skin="button-secondary"
+                    @icon="pencil"
+                    @iconAlignment="left"
+                  >
+                    Bewerk
+                  </AuLink>
+                  <ReportWrongData />
+                </div>
+              </:edit>
+            </SecuredArea>
+          {{else}}
+            <div class="au-u-flex--column">
+              <AuPill @icon="clock-rewind">
+                Laatst Gewijzigd op (Datum)
+              </AuPill>
+              <ReportWrongData />
+            </div>
+          {{/if}}
+        {{else}}
           <SecuredArea>
             <:edit>
-              <div class="au-u-flex--column">
-                <AuLink
-                  @route="administrative-units.administrative-unit.core-data.edit"
-                  @skin="button-secondary"
-                  @icon="pencil"
-                  @iconAlignment="left"
-                >
-                  Bewerk
-                </AuLink>
-                <ReportWrongData />
-              </div>
+              <AuLink
+                @route="administrative-units.administrative-unit.core-data.edit"
+                @skin="button-secondary"
+                @icon="pencil"
+                @iconAlignment="left"
+              >
+                Bewerk
+              </AuLink>
             </:edit>
+            <:readOnly>
+              <ReportWrongData />
+            </:readOnly>
           </SecuredArea>
-        {{else}}
-          <div class="au-u-flex--column">
-            <AuPill @icon="clock-rewind">
-              Laatst Gewijzigd op (Datum)
-            </AuPill>
-            <ReportWrongData />
-          </div>
         {{/if}}
-      {{else}}
-         <SecuredArea>
-          <:edit>
-            <AuLink
-              @route="administrative-units.administrative-unit.core-data.edit"
-              @skin="button-secondary"
-              @icon="pencil"
-              @iconAlignment="left"
-            >
-              Bewerk
-            </AuLink>
-          </:edit>
-          <:readOnly>
-            <ReportWrongData />
-          </:readOnly>
-        </SecuredArea>
-      {{/if}}    
       </:action>
     </PageHeader>
 
-{{!-- this is a feature for KBO data. where the backend is still in progress --}}
-{{#if (is-feature-enabled "kbo-data-tab")}}
-    <AuTabs as |Tab|>
-      <Tab class="au-u-1-1">
-        <AuLink
-          @skin="naked"
-          @width="block"
-          class={{if
-            this.showAbbData
-            "active tab-link-align-left"
-            "tab-link-align-left"
-          }}
-          {{on "click" (fn this.setShowAbbData true)}}
-        >ABB Gegevens</AuLink>
-      </Tab>
+    {{! this is a feature for KBO data. where the backend is still in progress }}
+    {{#if (is-feature-enabled "kbo-data-tab")}}
+      <AuTabs as |Tab|>
+        <Tab class="au-u-1-1">
+          <AuLink
+            @skin="naked"
+            @width="block"
+            class={{if
+              this.showAbbData
+              "active tab-link-align-left"
+              "tab-link-align-left"
+            }}
+            {{on "click" (fn this.setShowAbbData true)}}
+          >ABB Gegevens</AuLink>
+        </Tab>
 
-      <Tab class="au-u-1-1">
-        <AuLink
-          @skin="naked"
-          @width="block"
-          class={{if
-            this.showAbbData
-            "tab-link-align-left"
-            "active tab-link-align-left"
-          }}
-          {{on "click" (fn this.setShowAbbData false)}}
-        >KBO Gegevens</AuLink>
-      </Tab>
+        <Tab class="au-u-1-1">
+          <AuLink
+            @skin="naked"
+            @width="block"
+            class={{if
+              this.showAbbData
+              "tab-link-align-left"
+              "active tab-link-align-left"
+            }}
+            {{on "click" (fn this.setShowAbbData false)}}
+          >KBO Gegevens</AuLink>
+        </Tab>
 
-    </AuTabs>
-    {{#if this.showAbbData}}
+      </AuTabs>
+      {{#if this.showAbbData}}
+        <DataCard>
+          <:title>Bestuurseenheid</:title>
+          <:card as |Card|>
+            <Card.Columns>
+              <:left as |Item|>
+                <Item>
+                  <:label>Naam</:label>
+                  <:content>{{@model.administrativeUnit.abbName}}</:content>
+                </Item>
+                <Item>
+                  <:label>Juridische naam</:label>
+                  <:content>{{@model.administrativeUnit.legalName}}</:content>
+                </Item>
+                <Item>
+                  <:label>Type bestuur</:label>
+                  <:content>
+                    {{@model.administrativeUnit.classification.label}}
+                  </:content>
+                </Item>
+
+                {{#if this.isMunicipality}}
+                  <Item>
+                    <:label>Stadstitel</:label>
+                    <:content>
+                      {{#if @model.isCity}}
+                        Ja
+                      {{else}}
+                        Nee
+                      {{/if}}
+                    </:content>
+                  </Item>
+                {{/if}}
+
+                {{#if this.isWorshipService}}
+                  <Item>
+                    <:label>Soort eredienst</:label>
+                    <:content
+                    >{{@model.administrativeUnit.recognizedWorshipType.label}}</:content>
+                  </Item>
+                {{/if}}
+                {{#if @model.administrativeUnit.denomination}}
+                  <Item>
+                    <:label>Strekking</:label>
+                    <:content
+                    >{{@model.administrativeUnit.denomination}}</:content>
+                  </Item>
+                {{/if}}
+                {{#if
+                  (eq
+                    @model.administrativeUnit.constructor.modelName
+                    "worship-service"
+                  )
+                }}
+                  <Item>
+                    <:label>Grensoverschrijdend</:label>
+                    <:content>
+                      {{@model.administrativeUnit.crossBorderNominal}}
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if
+                  (and
+                    @model.administrativeUnit.scope.locatedWithin
+                    this.isMunicipality
+                  )
+                }}
+                  <Item>
+                    <:label>Regio</:label>
+                    <:content>
+                      {{@model.administrativeUnit.scope.locatedWithin.label}}
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if this.isIGS}}
+                  <Item>
+                    <:label>Regio</:label>
+                    <:content>
+                      {{@model.igsRegio.label}}
+                    </:content>
+                  </Item>
+                  {{#if @model.administrativeUnit.expectedEndDate}}
+                    <Item>
+                      <:label>Geplande einddatum</:label>
+                      <:content>
+                        {{date-format
+                          @model.administrativeUnit.expectedEndDate
+                        }}
+                        {{#if this.expiredExpectedEndDate}}
+                          <AuPill @skin="error">De geplande einddatum is
+                            overschreden</AuPill>
+                        {{/if}}
+                      </:content>
+                    </Item>
+                  {{/if}}
+                  {{#if @model.administrativeUnit.purpose}}
+                    <Item>
+                      <:label>Doel</:label>
+                      <:content>
+                        <RichTextEditor
+                          @show="true"
+                          @value={{@model.administrativeUnit.purpose}}
+                        />
+                      </:content>
+                    </Item>
+                  {{/if}}
+                {{/if}}
+              </:left>
+              <:right as |Item|>
+                <Item>
+                  <:label>Status</:label>
+                  <:content>
+                    <OrganizationStatus
+                      @id={{@model.administrativeUnit.organizationStatus.id}}
+                      @label={{@model.administrativeUnit.organizationStatus.label}}
+                    />
+                  </:content>
+                </Item>
+                {{#if @model.resultedFrom}}
+                  <Item>
+                    <:content>
+                      <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
+                        Gewijzigd op
+                        {{date-format (get @model.resultedFrom "0.date")}}
+                      </AuHelpText>
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if this.kboIdentifier.structuredIdentifier.localId}}
+                  <Item>
+                    <:label>{{this.kboIdentifier.idName}}</:label>
+                    <:content>
+                      {{kbo-format
+                        this.kboIdentifier.structuredIdentifier.localId
+                      }}
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if this.sharepointIdentifier.structuredIdentifier.localId}}
+                  <Item>
+                    <:label>{{this.sharepointIdentifier.idName}}</:label>
+                    <:content>
+                      <AuLinkExternal
+                        href="{{this.sharePointLinkBase}}{{this.sharepointIdentifier.structuredIdentifier.localId}}"
+                      >
+                        {{this.sharepointIdentifier.structuredIdentifier.localId}}
+                        (externe link)
+                      </AuLinkExternal>
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if
+                  (and
+                    @model.administrativeUnit.scope.exactMatch
+                    (or this.isMunicipality this.isProvince)
+                  )
+                }}
+                  <Item>
+                    <:label>NIS</:label>
+                    <:content>
+                      {{@model.administrativeUnit.scope.exactMatch.notation}}
+                    </:content>
+                  </Item>
+                {{/if}}
+                {{#if this.ovoIdentifier.structuredIdentifier.localId}}
+                  <Item>
+                    <:label>{{this.ovoIdentifier.idName}}</:label>
+                    <:content>
+                      {{this.ovoIdentifier.structuredIdentifier.localId}}
+                    </:content>
+                  </Item>
+                {{/if}}
+              </:right>
+            </Card.Columns>
+          </:card>
+        </DataCard>
+        <Site::ContactDataCard
+          @address={{@model.administrativeUnit.primarySite.address}}
+          @primaryContact={{@model.primaryContact}}
+          @secondaryContact={{@model.secondaryContact}}
+        >
+          <:title>
+            Primaire contactgegevens
+          </:title>
+        </Site::ContactDataCard>
+      {{else}}
+        <DataCard>
+          <:title>Bestuurseenheid</:title>
+          <:card as |Card|>
+            <Card.Columns>
+              <:left as |Item|>
+                <Item>
+                  <:label>Naam</:label>
+                  <:content>Aalst</:content>
+                </Item>
+                <Item>
+                  <:label>Commerciële naam</:label>
+                  <:content>
+                    Aalst
+                  </:content>
+                </Item>
+
+                <Item>
+                  <:label>Afgekorte naam</:label>
+                  <:content>
+                    Aalst
+                  </:content>
+                </Item>
+
+                <Item>
+                  <:label>Rechtsvorm</:label>
+                  <:content>
+                    RechtsVorm
+                  </:content>
+                </Item>
+              </:left>
+              <:right as |Item|>
+                <Item>
+                  <:label>Status</:label>
+                  <:content>
+                    <OrganizationStatus
+                      @id={{@model.administrativeUnit.organizationStatus.id}}
+                      @label={{@model.administrativeUnit.organizationStatus.label}}
+                    />
+                  </:content>
+                </Item>
+
+                <Item>
+                  <:label>Begindatum</:label>
+                  <:content>
+                    01-01-1990
+                  </:content>
+                </Item>
+
+                <Item>
+                  <:label>Ondernemingsnummer</:label>
+                  <:content>
+                    1274.374.678
+                  </:content>
+                </Item>
+                <Item>
+                  <:label>Website KBO</:label>
+                  <:content>
+                    <AuLinkExternal
+                      href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{this.kboIdentifier.structuredIdentifier.localId}}"
+                    >
+                      Link to page (externe link)
+                    </AuLinkExternal>
+                  </:content>
+                </Item>
+              </:right>
+            </Card.Columns>
+          </:card>
+        </DataCard>
+        <Site::ContactDataCard
+          @address={{@model.administrativeUnit.primarySite.address}}
+          @primaryContact={{@model.primaryContact}}
+          @secondaryContact={{@model.secondaryContact}}
+        >
+          <:title>
+            Maatschappelijke zetel
+          </:title>
+        </Site::ContactDataCard>
+      {{/if}}
+    {{else}}
+
       <DataCard>
         <:title>Bestuurseenheid</:title>
         <:card as |Card|>
@@ -88,7 +353,11 @@
             <:left as |Item|>
               <Item>
                 <:label>Naam</:label>
-                <:content>{{@model.administrativeUnit.name}}</:content>
+                <:content>{{@model.administrativeUnit.abbName}}</:content>
+              </Item>
+              <Item>
+                <:label>Juridische naam</:label>
+                <:content>{{@model.administrativeUnit.legalName}}</:content>
               </Item>
               <Item>
                 <:label>Type bestuur</:label>
@@ -150,11 +419,18 @@
                   </:content>
                 </Item>
               {{/if}}
-              {{#if this.isIGS}}
+              {{#if
+                (or
+                  this.isIGS
+                  this.isOcmwAssociation
+                  @model.administrativeUnit.isPevaMunicipality
+                  @model.administrativeUnit.isPevaProvince
+                )
+              }}
                 <Item>
                   <:label>Regio</:label>
                   <:content>
-                    {{@model.igsRegio.label}}
+                    {{@model.region.label}}
                   </:content>
                 </Item>
                 {{#if @model.administrativeUnit.expectedEndDate}}
@@ -250,6 +526,7 @@
           </Card.Columns>
         </:card>
       </DataCard>
+
       <Site::ContactDataCard
         @address={{@model.administrativeUnit.primarySite.address}}
         @primaryContact={{@model.primaryContact}}
@@ -259,271 +536,7 @@
           Primaire contactgegevens
         </:title>
       </Site::ContactDataCard>
-    {{else}}
-      <DataCard>
-        <:title>Bestuurseenheid</:title>
-        <:card as |Card|>
-          <Card.Columns>
-            <:left as |Item|>
-              <Item>
-                <:label>Naam</:label>
-                <:content>Aalst</:content>
-              </Item>
-              <Item>
-                <:label>Commerciële naam</:label>
-                <:content>
-                  Aalst
-                </:content>
-              </Item>
 
-              <Item>
-                <:label>Afgekorte naam</:label>
-                <:content>
-                  Aalst
-                </:content>
-              </Item>
-
-              <Item>
-                <:label>Rechtsvorm</:label>
-                <:content>
-                  RechtsVorm
-                </:content>
-              </Item>
-            </:left>
-            <:right as |Item|>
-              <Item>
-                <:label>Status</:label>
-                <:content>
-                  <OrganizationStatus
-                    @id={{@model.administrativeUnit.organizationStatus.id}}
-                    @label={{@model.administrativeUnit.organizationStatus.label}}
-                  />
-                </:content>
-              </Item>
-
-              <Item>
-                <:label>Begindatum</:label>
-                <:content>
-                  01-01-1990
-                </:content>
-              </Item>
-
-              <Item>
-                <:label>Ondernemingsnummer</:label>
-                <:content>
-                  1274.374.678
-                </:content>
-              </Item>
-              <Item>
-                <:label>Website KBO</:label>
-                <:content>
-                  <AuLinkExternal
-                    href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{this.kboIdentifier.structuredIdentifier.localId}}"
-                  >
-                    Link to page (externe link)
-                  </AuLinkExternal>
-                </:content>
-              </Item>
-            </:right>
-          </Card.Columns>
-        </:card>
-      </DataCard>
-      <Site::ContactDataCard
-        @address={{@model.administrativeUnit.primarySite.address}}
-        @primaryContact={{@model.primaryContact}}
-        @secondaryContact={{@model.secondaryContact}}
-      >
-        <:title>
-          Maatschappelijke zetel
-        </:title>
-      </Site::ContactDataCard>
     {{/if}}
-  {{else}}
-
-   <DataCard>
-      <:title>Bestuurseenheid</:title>
-      <:card as |Card|>
-        <Card.Columns>
-          <:left as |Item|>
-            <Item>
-              <:label>Naam</:label>
-              <:content>{{@model.administrativeUnit.name}}</:content>
-            </Item>
-            <Item>
-              <:label>Type bestuur</:label>
-              <:content>
-                {{@model.administrativeUnit.classification.label}}
-              </:content>
-            </Item>
-
-            {{#if this.isMunicipality}}
-              <Item>
-                <:label>Stadstitel</:label>
-                <:content>
-                  {{#if @model.isCity}}
-                    Ja
-                  {{else}}
-                    Nee
-                  {{/if}}
-                </:content>
-              </Item>
-            {{/if}}
-
-            {{#if this.isWorshipService}}
-              <Item>
-                <:label>Soort eredienst</:label>
-                <:content
-                >{{@model.administrativeUnit.recognizedWorshipType.label}}</:content>
-              </Item>
-            {{/if}}
-            {{#if @model.administrativeUnit.denomination}}
-              <Item>
-                <:label>Strekking</:label>
-                <:content>{{@model.administrativeUnit.denomination}}</:content>
-              </Item>
-            {{/if}}
-            {{#if
-              (eq
-                @model.administrativeUnit.constructor.modelName
-                "worship-service"
-              )
-            }}
-              <Item>
-                <:label>Grensoverschrijdend</:label>
-                <:content>
-                  {{@model.administrativeUnit.crossBorderNominal}}
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if
-              (and
-                @model.administrativeUnit.scope.locatedWithin
-                this.isMunicipality
-              )
-            }}
-              <Item>
-                <:label>Regio</:label>
-                <:content>
-                  {{@model.administrativeUnit.scope.locatedWithin.label}}
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if
-              (or
-                this.isIGS
-                this.isOcmwAssociation
-                @model.administrativeUnit.isPevaMunicipality
-                @model.administrativeUnit.isPevaProvince
-              )
-            }}
-              <Item>
-                <:label>Regio</:label>
-                <:content>
-                  {{@model.region.label}}
-                </:content>
-              </Item>
-              {{#if @model.administrativeUnit.expectedEndDate}}
-                <Item>
-                  <:label>Geplande einddatum</:label>
-                  <:content>
-                    {{date-format @model.administrativeUnit.expectedEndDate}}
-                    {{#if this.expiredExpectedEndDate}}
-                      <AuPill @skin="error">De geplande einddatum is
-                        overschreden</AuPill>
-                    {{/if}}
-                  </:content>
-                </Item>
-              {{/if}}
-              {{#if @model.administrativeUnit.purpose}}
-                <Item>
-                  <:label>Doel</:label>
-                  <:content>
-                    <RichTextEditor
-                      @show="true"
-                      @value={{@model.administrativeUnit.purpose}}
-                    />
-                  </:content>
-                </Item>
-              {{/if}}
-            {{/if}}
-          </:left>
-          <:right as |Item|>
-            <Item>
-              <:label>Status</:label>
-              <:content>
-                <OrganizationStatus
-                  @id={{@model.administrativeUnit.organizationStatus.id}}
-                  @label={{@model.administrativeUnit.organizationStatus.label}}
-                />
-              </:content>
-            </Item>
-            {{#if @model.resultedFrom}}
-              <Item>
-                <:content>
-                  <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
-                    Gewijzigd op
-                    {{date-format (get @model.resultedFrom "0.date")}}
-                  </AuHelpText>
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if this.kboIdentifier.structuredIdentifier.localId}}
-              <Item>
-                <:label>{{this.kboIdentifier.idName}}</:label>
-                <:content>
-                  {{kbo-format this.kboIdentifier.structuredIdentifier.localId}}
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if this.sharepointIdentifier.structuredIdentifier.localId}}
-              <Item>
-                <:label>{{this.sharepointIdentifier.idName}}</:label>
-                <:content>
-                  <AuLinkExternal
-                    href="{{this.sharePointLinkBase}}{{this.sharepointIdentifier.structuredIdentifier.localId}}"
-                  >
-                    {{this.sharepointIdentifier.structuredIdentifier.localId}}
-                    (externe link)
-                  </AuLinkExternal>
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if
-              (and
-                @model.administrativeUnit.scope.exactMatch
-                (or this.isMunicipality this.isProvince)
-              )
-            }}
-              <Item>
-                <:label>NIS</:label>
-                <:content>
-                  {{@model.administrativeUnit.scope.exactMatch.notation}}
-                </:content>
-              </Item>
-            {{/if}}
-            {{#if this.ovoIdentifier.structuredIdentifier.localId}}
-              <Item>
-                <:label>{{this.ovoIdentifier.idName}}</:label>
-                <:content>
-                  {{this.ovoIdentifier.structuredIdentifier.localId}}
-                </:content>
-              </Item>
-            {{/if}}
-          </:right>
-        </Card.Columns>
-      </:card>
-    </DataCard>
-
-    <Site::ContactDataCard
-      @address={{@model.administrativeUnit.primarySite.address}}
-      @primaryContact={{@model.primaryContact}}
-      @secondaryContact={{@model.secondaryContact}}
-    >
-      <:title>
-        Primaire contactgegevens
-      </:title>
-    </Site::ContactDataCard>
-  
-{{/if}}
   </div>
 </div>

--- a/app/templates/administrative-units/administrative-unit/executives.hbs
+++ b/app/templates/administrative-units/administrative-unit/executives.hbs
@@ -8,7 +8,7 @@
 
 <PageHeader class="au-o-box">
   <:title>Leidinggevenden</:title>
-  <:subtitle>{{@model.administrativeUnit.name}}
+  <:subtitle>{{@model.administrativeUnit.abbName}}
     ({{@model.administrativeUnit.classification.label}})</:subtitle>
 </PageHeader>
 

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/edit.hbs
@@ -4,7 +4,7 @@
       <:title>Bewerk bestuursorgaan</:title>
       <:subtitle>
         {{@model.governingBodyClassification.label}}
-        {{@model.administrativeUnit.name}}
+        {{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})
       </:subtitle>
       <:action>

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/governing-body/index.hbs
@@ -5,7 +5,7 @@
         Bestuursorgaan:
         {{@model.governingBodyClassification.label}}
       </:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <SecuredArea>

--- a/app/templates/administrative-units/administrative-unit/governing-bodies/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/governing-bodies/index.hbs
@@ -1,6 +1,7 @@
 <PageHeader class="au-o-box">
   <:title>Bestuursorganen</:title>
-  <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+  <:subtitle>{{@model.administrativeUnit.abbName}}
+    ({{@model.administrativeUnit.classification.label}})</:subtitle>
   <:alert>
     <SecuredArea>
       <:edit>
@@ -51,7 +52,10 @@
         </AuLink>
       </td>
       <td>{{governingBody.period}}</td>
-      <td><GoverningBodyStatus @startDate={{governingBody.startDate}} @endDate={{governingBody.endDate}} /></td>
+      <td><GoverningBodyStatus
+          @startDate={{governingBody.startDate}}
+          @endDate={{governingBody.endDate}}
+        /></td>
       <SecuredArea>
         <:edit>
           <td>

--- a/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/local-involvements/edit.hbs
@@ -2,7 +2,7 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   <PageHeader class="au-o-box">
     <:title>Bewerk betrokken lokale besturen</:title>
-    <:subtitle>{{@model.worshipAdministrativeUnit.name}}</:subtitle>
+    <:subtitle>{{@model.worshipAdministrativeUnit.abbName}}</:subtitle>
     <:action>
       <div class="au-u-text-right">
         <AuButtonGroup class="au-c-button-group--align-right">
@@ -75,7 +75,7 @@
                 @classificationCodes={{this.classificationCodes}}
                 as |administrativeUnit|
               >
-                {{administrativeUnit.name}}
+                {{administrativeUnit.abbName}}
                 ({{administrativeUnit.classification.label}})
               </AdministrativeUnitSelect>
               {{#if errorMessage}}
@@ -92,10 +92,7 @@
             />
           </td>
           <td>
-            {{#let
-              involvement.error.involvementType.message
-              as |errorMessage|
-            }}
+            {{#let involvement.error.involvementType.message as |errorMessage|}}
               <div class={{if errorMessage "ember-power-select--error"}}>
                 {{#if this.isWorshipService}}
                   {{#if

--- a/app/templates/administrative-units/administrative-unit/local-involvements/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/local-involvements/index.hbs
@@ -1,6 +1,6 @@
 <PageHeader class="au-o-box">
   <:title>Betrokken lokale besturen</:title>
-  <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
+  <:subtitle>{{@model.administrativeUnit.abbName}}</:subtitle>
   <:action>
     <SecuredArea>
       <:edit>
@@ -54,7 +54,7 @@
       {{/if}}
     </c.header>
     <c.body as |involvement|>
-      <td>{{involvement.administrativeUnit.name}}</td>
+      <td>{{involvement.administrativeUnit.abbName}}</td>
       <td>{{involvement.administrativeUnit.classification.label}}</td>
       <td>{{involvement.involvementType.label}}</td>
       {{#if this.isWorshipService}}

--- a/app/templates/administrative-units/administrative-unit/ministers/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/ministers/index.hbs
@@ -1,6 +1,6 @@
 <PageHeader class="au-o-box">
   <:title>Bedienaren</:title>
-  <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
+  <:subtitle>{{@model.administrativeUnit.abbName}}</:subtitle>
   <:action>
     <SecuredArea>
       <:readOnly>
@@ -23,27 +23,27 @@
       <th class="au-c-data-table__header-title">Status</th>
     </c.header>
     <c.body as |minister|>
-        <td>
-          <AuLink @route="people.person" @model={{minister.person.id}}>
-            {{minister.person.givenName}}
-          </AuLink>
-        </td>
-        <td>
-          <AuLink @route="people.person" @model={{minister.person.id}}>
-            {{minister.person.familyName}}
-          </AuLink>
-        </td>
-        <td>
-          <AuLink
-            @route="people.person.positions.minister"
-            @models={{array minister.person.id minister.id}}
-          >
-            {{minister.ministerPosition.function.label}}
-          </AuLink>
-        </td>
-        <td>
-          <PositionStatus @endDate={{minister.agentEndDate}} />
-        </td>
+      <td>
+        <AuLink @route="people.person" @model={{minister.person.id}}>
+          {{minister.person.givenName}}
+        </AuLink>
+      </td>
+      <td>
+        <AuLink @route="people.person" @model={{minister.person.id}}>
+          {{minister.person.familyName}}
+        </AuLink>
+      </td>
+      <td>
+        <AuLink
+          @route="people.person.positions.minister"
+          @models={{array minister.person.id minister.id}}
+        >
+          {{minister.ministerPosition.function.label}}
+        </AuLink>
+      </td>
+      <td>
+        <PositionStatus @endDate={{minister.agentEndDate}} />
+      </td>
     </c.body>
   </t.content>
 </AuDataTable>

--- a/app/templates/administrative-units/administrative-unit/related-organizations/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/related-organizations/edit.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-box">
     <PageHeader class="au-u-margin-bottom-large">
       <:title>Bewerk gerelateerde organisaties</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         <div class="au-u-text-right">

--- a/app/templates/administrative-units/administrative-unit/related-organizations/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/related-organizations/index.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Gerelateerde organisaties</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}
+      <:subtitle>{{@model.administrativeUnit.abbName}}
         ({{@model.administrativeUnit.classification.label}})</:subtitle>
       <:action>
         {{#if (not (or this.isDistrict this.isProvince))}}

--- a/app/templates/administrative-units/administrative-unit/sites/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/index.hbs
@@ -1,6 +1,7 @@
 <PageHeader class="au-o-box">
   <:title>Vestigingen</:title>
-  <:subtitle>{{@model.administrativeUnit.name}} ({{@model.administrativeUnit.classification.label}})</:subtitle>
+  <:subtitle>{{@model.administrativeUnit.abbName}}
+    ({{@model.administrativeUnit.classification.label}})</:subtitle>
   <:action>
     <SecuredArea>
       <:edit>

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -4,7 +4,7 @@
       <:title>Bewerk vestiging</:title>
       <:subtitle>
         {{this.model.address.fullAddress}},
-        {{this.model.administrativeUnit.name}}
+        {{this.model.administrativeUnit.abbName}}
       </:subtitle>
       <:action>
         <div class="au-u-text-right">
@@ -58,18 +58,16 @@
                   </:content>
                 </Item>
                 {{#if this.model.site.isOtherSite}}
-                  <Item
-                    @labelFor="site-type-name"
-                  >
+                  <Item @labelFor="site-type-name">
                     <:label>Name</:label>
                     <:content>
-                     <AuInput
-                      @selected={{this.model.site.siteTypeName}}
-                      {{on "input" this.setSiteTypeName}}
-                      value={{this.model.site.siteTypeName}}
-                      @width="block"
-                      maxlength="50"
-                     />
+                      <AuInput
+                        @selected={{this.model.site.siteTypeName}}
+                        {{on "input" this.setSiteTypeName}}
+                        value={{this.model.site.siteTypeName}}
+                        @width="block"
+                        maxlength="50"
+                      />
                     </:content>
                   </Item>
                 {{/if}}

--- a/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
@@ -2,7 +2,7 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Vestiging: {{@model.site.address.fullAddress}}</:title>
-      <:subtitle>{{@model.administrativeUnit.name}}</:subtitle>
+      <:subtitle>{{@model.administrativeUnit.abbName}}</:subtitle>
       <:action>
         <SecuredArea>
           <:edit>
@@ -31,7 +31,7 @@
               <:label>Type vestiging</:label>
               <:content>{{@model.site.siteType.label}}</:content>
             </Item>
-            {{#if  (and @model.site.isOtherSite @model.site.siteTypeName)}}
+            {{#if (and @model.site.isOtherSite @model.site.siteTypeName)}}
               <Item>
                 <:label>Name</:label>
                 <:content>{{@model.site.siteTypeName}}</:content>

--- a/app/templates/administrative-units/index.hbs
+++ b/app/templates/administrative-units/index.hbs
@@ -168,7 +168,11 @@
           <c.body as |adminUnit|>
             <td>
               <AuLink @route={{adminUnit.route}} @model={{adminUnit.id}}>
-                {{adminUnit.name}}
+                {{#if adminUnit.legal_name}}
+                  {{adminUnit.legal_name}}
+                {{else}}
+                  {{adminUnit.name}}
+                {{/if}}
               </AuLink>
             </td>
             <td>{{adminUnit.classification_name}}</td>

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -36,20 +36,39 @@
       <:card as |Card|>
         <Card.Columns>
           <:left as |Item|>
-            <Item
-              @labelFor="administrative-unit-name"
-              @required={{true}}
-              @errorMessage={{@model.administrativeUnit.error.name.message}}
-            >
+            <Item @labelFor="administrative-unit-abb-name" @required={{true}}>
               <:label>Naam</:label>
               <:content as |hasError|>
                 <TrimInput
                   @width="block"
-                  @value={{@model.administrativeUnit.name}}
+                  @disabled={{true}}
+                  @value={{@model.administrativeUnit.abbName}}
                   @onUpdate={{fn (mut @model.administrativeUnit.name)}}
                   @error={{hasError}}
-                  id="administrative-unit-name"
+                  id="administrative-unit-abb-name"
                 />
+                <AuHelpText>
+                  {{help-text "abbName"}}
+                </AuHelpText>
+              </:content>
+            </Item>
+            <Item
+              @labelFor="administrative-unit-legal-name"
+              @required={{true}}
+              @errorMessage={{@model.administrativeUnit.error.legalName.message}}
+            >
+              <:label>Juridische naam</:label>
+              <:content as |hasError|>
+                <TrimInput
+                  @width="block"
+                  @value={{@model.administrativeUnit.legalName}}
+                  @onUpdate={{this.setNames}}
+                  @error={{hasError}}
+                  id="administrative-unit-legal-name"
+                />
+                <AuHelpText>
+                  {{help-text "legalName"}}
+                </AuHelpText>
               </:content>
             </Item>
             <Item
@@ -342,7 +361,7 @@
                         Provincie
                       </:label>
                       <:content>
-                        {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.name}}
+                        {{@model.administrativeUnit.isSubOrganizationOf.isSubOrganizationOf.abbName}}
                       </:content>
                     </Item>
                   {{/if}}

--- a/app/templates/organizations/organization.hbs
+++ b/app/templates/organizations/organization.hbs
@@ -1,6 +1,6 @@
-{{page-title this.model.name}}
+{{page-title this.model.abbName}}
 {{breadcrumb
-  this.model.name
+  this.model.abbName
   route="organizations.organization"
   model=this.model.id
 }}
@@ -15,7 +15,9 @@
           </AuNavigationLink>
         </li>
         <li class="au-c-list-navigation__item">
-          <AuNavigationLink @route="organizations.organization.related-organizations">
+          <AuNavigationLink
+            @route="organizations.organization.related-organizations"
+          >
             Gerelateerde organisaties
           </AuNavigationLink>
         </li>

--- a/app/templates/organizations/organization/core-data.hbs
+++ b/app/templates/organizations/organization/core-data.hbs
@@ -4,7 +4,7 @@
   <div class="au-o-box au-o-flow au-o-flow--large">
     <PageHeader>
       <:title>Kerngegevens</:title>
-      <:subtitle>{{@model.representativeBody.name}}</:subtitle>
+      <:subtitle>{{@model.representativeBody.abbName}}</:subtitle>
     </PageHeader>
 
     <DataCard>
@@ -14,11 +14,16 @@
           <:left as |Item|>
             <Item>
               <:label>Naam</:label>
-              <:content>{{@model.representativeBody.name}}</:content>
+              <:content>{{@model.representativeBody.abbName}}</:content>
+            </Item>
+            <Item>
+              <:label>Juridische naam</:label>
+              <:content>{{@model.representativeBody.legalName}}</:content>
             </Item>
             <Item>
               <:label>Soort eredienst</:label>
-              <:content>{{@model.representativeBody.recognizedWorshipType.label}}</:content>
+              <:content
+              >{{@model.representativeBody.recognizedWorshipType.label}}</:content>
             </Item>
           </:left>
           <:right as |Item|>
@@ -36,8 +41,10 @@
               <Item>
                 <:content>
                   <AuHelpText @skin="tertiary">Gewijzigd op
-                    {{date-format (get @model.representativeBody.resultedFrom "0.date")}}
-                    </AuHelpText>
+                    {{date-format
+                      (get @model.representativeBody.resultedFrom "0.date")
+                    }}
+                  </AuHelpText>
                 </:content>
               </Item>
             {{/if}}
@@ -77,7 +84,12 @@
               <Item>
                 <:label>Telefoonnummer</:label>
                 <:content>
-                  {{tel-format (get @model.representativeBody.primarySite.contacts "0.telephone")}}
+                  {{tel-format
+                    (get
+                      @model.representativeBody.primarySite.contacts
+                      "0.telephone"
+                    )
+                  }}
                 </:content>
               </Item>
             {{/if}}
@@ -96,11 +108,18 @@
                 <:label>Website</:label>
                 <:content>
                   <a
-                    href={{get @model.representativeBody.primarySite.contacts "0.website"}}
+                    href={{get
+                      @model.representativeBody.primarySite.contacts
+                      "0.website"
+                    }}
                     class="au-c-link"
                     target="_blank"
                     rel="noopener noreferrer"
-                  >{{get @model.representativeBody.primarySite.contacts "0.website"}} (externe link)</a>
+                  >{{get
+                      @model.representativeBody.primarySite.contacts
+                      "0.website"
+                    }}
+                    (externe link)</a>
                 </:content>
               </Item>
             {{/if}}

--- a/app/templates/organizations/organization/related-organizations.hbs
+++ b/app/templates/organizations/organization/related-organizations.hbs
@@ -9,16 +9,19 @@
 <div class="au-c-body-container au-c-body-container--scroll">
   <PageHeader class="au-o-box">
     <:title>Gerelateerde organisaties</:title>
-    <:subtitle>{{@model.organization.name}}</:subtitle>
+    <:subtitle>{{@model.organization.abbName}}</:subtitle>
   </PageHeader>
 
-  <AuDataTable id="subOrganizations"
+  <AuDataTable
+    id="subOrganizations"
     @content={{this.subOrganizations}}
     @isLoading={{this.isLoading}}
     @sort={{this.sort}}
     @page={{this.page}}
     @size={{this.size}}
-    @noDataMessage="Geen bestuur" as |t|>
+    @noDataMessage="Geen bestuur"
+    as |t|
+  >
     <t.menu as |menu|>
       <menu.general>
         <div class="au-o-box">
@@ -31,22 +34,39 @@
     </t.menu>
     <t.content as |c|>
       <c.header>
-        <AuDataTableThSortable @field="classification.label" @currentSorting={{this.sort}} @label="Type organisatie" />
-        <AuDataTableThSortable @field="name" @currentSorting={{this.sort}} @label="Organisatie" />
-        <AuDataTableThSortable @field="organizationStatus.label" @currentSorting={{this.sort}} @label="Status" />
+        <AuDataTableThSortable
+          @field="classification.label"
+          @currentSorting={{this.sort}}
+          @label="Type organisatie"
+        />
+        <AuDataTableThSortable
+          @field="name"
+          @currentSorting={{this.sort}}
+          @label="Organisatie"
+        />
+        <AuDataTableThSortable
+          @field="organizationStatus.label"
+          @currentSorting={{this.sort}}
+          @label="Status"
+        />
       </c.header>
       <c.body as |subOrganization|>
         <td>
           {{subOrganization.classification.label}}
         </td>
         <td>
-          <AuLink @route="administrative-units.administrative-unit" @model={{subOrganization.id}}>
-            {{subOrganization.name}}
+          <AuLink
+            @route="administrative-units.administrative-unit"
+            @model={{subOrganization.id}}
+          >
+            {{subOrganization.abbName}}
           </AuLink>
         </td>
         <td>
-          <OrganizationStatus @id={{subOrganization.organizationStatus.id}}
-            @label={{subOrganization.organizationStatus.label}} />
+          <OrganizationStatus
+            @id={{subOrganization.organizationStatus.id}}
+            @label={{subOrganization.organizationStatus.label}}
+          />
         </td>
       </c.body>
     </t.content>

--- a/app/templates/people/person/personal-information/index.hbs
+++ b/app/templates/people/person/personal-information/index.hbs
@@ -144,7 +144,7 @@
                       @model={{position.administrativeUnit.id}}
                       @route="administrative-units.administrative-unit"
                     >
-                      {{position.administrativeUnit.name}}
+                      {{position.administrativeUnit.abbName}}
                     </AuLink>
                   </:content>
                 </Item>
@@ -160,7 +160,7 @@
                         @model={{administrativeUnit.id}}
                         @route="administrative-units.administrative-unit"
                       >
-                        {{administrativeUnit.name}}
+                        {{administrativeUnit.abbName}}
                         ({{administrativeUnit.classification.label}})
                       </AuLink>
                       {{#if (gt position.administrativeUnits.length 1)}}

--- a/app/templates/people/person/positions/functionary/index.hbs
+++ b/app/templates/people/person/positions/functionary/index.hbs
@@ -7,7 +7,7 @@
         <br />
         {{#each @model.governingBodies as |governingBody|}}
           {{governingBody.administrativeUnit.classification.label}}
-          {{governingBody.administrativeUnit.name}}
+          {{governingBody.administrativeUnit.abbName}}
           <br />
         {{/each}}
       </:title>
@@ -44,7 +44,7 @@
                     @route="administrative-units.administrative-unit"
                     @model={{administrativeUnit.id}}
                   >
-                    {{administrativeUnit.name}}
+                    {{administrativeUnit.abbName}}
                     ({{administrativeUnit.classification.label}})
                   </AuLink>
                   {{#if (gt @model.administrativeUnits.length 1)}}

--- a/app/templates/people/person/positions/index.hbs
+++ b/app/templates/people/person/positions/index.hbs
@@ -72,7 +72,7 @@
             @route="administrative-units.administrative-unit"
             @model={{position.administrativeUnit.id}}
           >
-            {{position.administrativeUnit.name}}
+            {{position.administrativeUnit.abbName}}
           </AuLink>
         {{else}}
           {{#each position.administrativeUnits as |administrativeUnit index|}}
@@ -80,7 +80,7 @@
               @route="administrative-units.administrative-unit"
               @model={{administrativeUnit.id}}
             >
-              {{administrativeUnit.name}}
+              {{administrativeUnit.abbName}}
               ({{administrativeUnit.classification.label}})
             </AuLink>
             {{#if (gt position.administrativeUnits.length 1)}}

--- a/app/templates/people/person/positions/mandatory/index.hbs
+++ b/app/templates/people/person/positions/mandatory/index.hbs
@@ -11,7 +11,7 @@
           {{@model.mandatory.mandate.roleBoard.label}},
           <br />
           {{governingBody.classification.label}}
-          {{governingBody.administrativeUnit.name}}
+          {{governingBody.administrativeUnit.abbName}}
         </:title>
         <:subtitle>
           {{@model.person.givenName}}
@@ -49,7 +49,7 @@
                     @route="administrative-units.administrative-unit"
                     @model={{administrativeUnit.id}}
                   >
-                    {{administrativeUnit.name}}
+                    {{administrativeUnit.abbName}}
                   </AuLink>
                 </:content>
               </Item>

--- a/app/templates/people/person/positions/minister/index.hbs
+++ b/app/templates/people/person/positions/minister/index.hbs
@@ -5,7 +5,7 @@
         Positie:
         {{@model.minister.ministerPosition.function.label}}
         <br />
-        {{@model.minister.ministerPosition.worshipService.name}}
+        {{@model.minister.ministerPosition.worshipService.abbName}}
       </:title>
       <:subtitle>
         {{@model.person.givenName}}
@@ -47,7 +47,7 @@
                     @route="administrative-units.administrative-unit"
                     @model={{administrativeUnit.id}}
                   >
-                    {{administrativeUnit.name}}
+                    {{administrativeUnit.abbName}}
                   </AuLink>
                 {{/let}}
               </:content>
@@ -71,14 +71,18 @@
             <:left as |Item|>
               <Item>
                 <:label>Startdatum</:label>
-                <:content>{{date-format @model.minister.agentStartDate}}</:content>
+                <:content>{{date-format
+                    @model.minister.agentStartDate
+                  }}</:content>
               </Item>
             </:left>
             <:right as |Item|>
               {{#if @model.minister.agentEndDate}}
                 <Item>
                   <:label>Einddatum</:label>
-                  <:content>{{date-format @model.minister.agentEndDate}}</:content>
+                  <:content>{{date-format
+                      @model.minister.agentEndDate
+                    }}</:content>
                 </Item>
               {{/if}}
             </:right>

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -19,7 +19,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 3);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
       });
@@ -40,7 +40,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 5);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         expectedEndDate: {
           message: 'De datum mag niet in het verleden liggen',
         },
@@ -70,7 +70,7 @@ module('Unit | Model | administrative unit', function (hooks) {
         assert.false(isValid);
         assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
-          name: { message: 'Vul de naam in' },
+          legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
           wasFoundedByOrganizations: { message: 'Selecteer een optie' },
         });
@@ -97,7 +97,7 @@ module('Unit | Model | administrative unit', function (hooks) {
         assert.false(isValid);
         assert.strictEqual(Object.keys(model.error).length, 3);
         assert.propContains(model.error, {
-          name: { message: 'Vul de naam in' },
+          legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
           wasFoundedByOrganizations: { message: 'Selecteer een optie' },
         });
@@ -126,7 +126,7 @@ module('Unit | Model | administrative unit', function (hooks) {
         assert.false(isValid);
         assert.strictEqual(Object.keys(model.error).length, 2);
         assert.propContains(model.error, {
-          name: { message: 'Vul de naam in' },
+          legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
         });
       });
@@ -148,7 +148,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 3);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         isSubOrganizationOf: { message: 'Selecteer een optie' },
       });
@@ -170,7 +170,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         isAssociatedWith: { message: 'Selecteer een optie' },
         isSubOrganizationOf: { message: 'Selecteer een optie' },
@@ -199,7 +199,7 @@ module('Unit | Model | administrative unit', function (hooks) {
         assert.false(isValid);
         assert.strictEqual(Object.keys(model.error).length, 2);
         assert.propContains(model.error, {
-          name: { message: 'Vul de naam in' },
+          legalName: { message: 'Vul de juridische naam in' },
           organizationStatus: { message: 'Selecteer een optie' },
         });
       });
@@ -219,7 +219,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 4);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         wasFoundedByOrganizations: { message: 'Selecteer een optie' },
         isSubOrganizationOf: { message: 'Selecteer een optie' },
@@ -240,7 +240,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 5);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
         isAssociatedWith: { message: 'Selecteer een optie' },
         wasFoundedByOrganizations: { message: 'Selecteer een optie' },

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -18,7 +18,7 @@ module('Unit | Model | organization', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 2);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         organizationStatus: { message: 'Selecteer een optie' },
       });
     });

--- a/tests/unit/models/worship-administrative-unit-test.js
+++ b/tests/unit/models/worship-administrative-unit-test.js
@@ -18,7 +18,7 @@ module('Unit | Model | worship administrative unit', function (hooks) {
       assert.false(isValid);
       assert.strictEqual(Object.keys(model.error).length, 3);
       assert.propContains(model.error, {
-        name: { message: 'Vul de naam in' },
+        legalName: { message: 'Vul de juridische naam in' },
         classification: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
       });


### PR DESCRIPTION
OP-2998 and OP-2999

# Summary
- Added a mandatory `legalName` attribute to the `organization` model, `name` attribute is no longer mandatory
- Replaced displaying of the `name` attribute by a function `abbName` that returns the `legalName` and falls back to `name` if that is not available
- Extended the (edit) core data forms with fields for `legalName`
- After creation, an organisation's legal name can only be edited for some classifications (see table in OP-2999, note during standup of 29/02 we decided that for municipalities and provinces the legal name should also be not editable either)
- The `name` attribute can no longer be directly edited by users
- When an organisation's legal name is edited, the value of both `legalName` and `name` is updated
- Extended the name search to include the name as well as legal name (requires a reindex to work)

# Notes
- The changes to `core-data/index.hbs` are mostly automatic formatting. The relevant changes in that file are the changes from `name` to `abbName` to print an organisation's name and the addition of the items for displaying the legal name.

# TODO
- [ ] Use registered KBO name as fallback value for ABB name, depends on #578 