### PR TITLE
Fix: relax requirement of founding organization for newly onboarded unit types

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -123,7 +123,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
     } = this.model;
 
     yield Promise.all([
-      administrativeUnit.validate(),
+      administrativeUnit.validate(true),
       address.validate(),
       contact.validate(),
       secondaryContact.validate(),

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -123,7 +123,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
     } = this.model;
 
     yield Promise.all([
-      administrativeUnit.validate(true),
+      administrativeUnit.validate({ relaxMandatoryFoundingOrganization: true }),
       address.validate(),
       contact.validate(),
       secondaryContact.validate(),

--- a/app/models/abstract-validation-model.js
+++ b/app/models/abstract-validation-model.js
@@ -25,12 +25,10 @@ export default class AbstractValidationModel extends Model {
 
   /**
    * Validate the model using the validation schema.
-   * @param {boolean} relaxMandatoryFoundingOrganization - if true, the
-   * requirement to specify a founding organisation is not enforced for OCMW
-   * associations and PEVAs
+   * @param {object} [options] - The options for validation.
    * @returns {Promise<boolean>} - Whether the model is valid.
    */
-  async validate(relaxMandatoryFoundingOrganization) {
+  async validate(options = {}) {
     this._validationError = undefined;
     const { attributes, relationships } = this.#serializeAll();
     const value = { ...attributes, ...relationships };
@@ -40,7 +38,7 @@ export default class AbstractValidationModel extends Model {
         abortEarly: false,
         context: {
           changedAttributes: this.changedAttributes(),
-          relaxMandatoryFoundingOrganization,
+          ...options,
         },
       });
     } catch (error) {

--- a/app/models/abstract-validation-model.js
+++ b/app/models/abstract-validation-model.js
@@ -25,9 +25,12 @@ export default class AbstractValidationModel extends Model {
 
   /**
    * Validate the model using the validation schema.
+   * @param {boolean} relaxMandatoryFoundingOrganization - if true, the
+   * requirement to specify a founding organisation is not enforced for OCMW
+   * associations and PEVAs
    * @returns {Promise<boolean>} - Whether the model is valid.
    */
-  async validate() {
+  async validate(relaxMandatoryFoundingOrganization) {
     this._validationError = undefined;
     const { attributes, relationships } = this.#serializeAll();
     const value = { ...attributes, ...relationships };
@@ -37,6 +40,7 @@ export default class AbstractValidationModel extends Model {
         abortEarly: false,
         context: {
           changedAttributes: this.changedAttributes(),
+          relaxMandatoryFoundingOrganization,
         },
       });
     } catch (error) {

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -76,15 +76,25 @@ export default class AdministrativeUnitModel extends OrganizationModel {
         IGSCodeList,
         REQUIRED_MESSAGE
       ),
-      wasFoundedByOrganizations: validateRequiredWhenClassificationId(
-        [
-          ...AgbCodeList,
-          ...ApbCodeList,
-          ...OcmwAssociationCodeList,
-          ...PevaMunicipalityCodeList,
-          ...PevaProvinceCodeList,
-        ],
-        REQUIRED_MESSAGE
+      wasFoundedByOrganizations: Joi.when(
+        Joi.ref('$relaxMandatoryFoundingOrganization'),
+        {
+          is: Joi.exist().valid(true),
+          then: validateRequiredWhenClassificationId(
+            [...AgbCodeList, ...ApbCodeList],
+            REQUIRED_MESSAGE
+          ),
+          otherwise: validateRequiredWhenClassificationId(
+            [
+              ...AgbCodeList,
+              ...ApbCodeList,
+              ...OcmwAssociationCodeList,
+              ...PevaMunicipalityCodeList,
+              ...PevaProvinceCodeList,
+            ],
+            REQUIRED_MESSAGE
+          ),
+        }
       ),
       isSubOrganizationOf: validateRequiredWhenClassificationId(
         [

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -77,6 +77,15 @@ export default class AdministrativeUnitModel extends OrganizationModel {
         REQUIRED_MESSAGE
       ),
       wasFoundedByOrganizations: Joi.when(
+        // Note: For OCMW associations and PEVAs a founding organisation is
+        // normally mandatory. But the available business data when onboarding
+        // them was incomplete in this respect. Therefore, we opted to relax
+        // this rule for the OCMW associations and PEVAs imported during the
+        // onboarding. The `relaxMandatoryFoundingOrganization` option allows us
+        // to specify that a founding organisation is not mandatory in, for
+        // example, the edit core data form. Otherwise, the form validation
+        // would prevent editing the core data of the imported organisations due
+        // to the lack of founding organisation.
         Joi.ref('$relaxMandatoryFoundingOrganization'),
         {
           is: Joi.exist().valid(true),

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -407,7 +407,7 @@
                     {{#if @model.administrativeUnit.isOcmwAssociation}}
                       <Item
                         @labelFor="oprichting-ocmw-association"
-                        @required={{true}}
+                        @required={{false}}
                         @errorMessage={{@model.administrativeUnit.error.wasFoundedByOrganizations.message}}
                       >
                         <:label>Werd opgericht door</:label>
@@ -448,7 +448,7 @@
                       }}
                         <Item
                           @labelFor="oprichting-peva"
-                          @required={{true}}
+                          @required={{false}}
                           @errorMessage={{@model.administrativeUnit.error.wasFoundedByOrganizations.message}}
                         >
                           <:label>Werd opgericht door</:label>

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -183,7 +183,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       CLASSIFICATION.PEVA_MUNICIPALITY,
       CLASSIFICATION.PEVA_PROVINCE,
     ].forEach((cl) => {
-      test(`it returns no extra error when founder is missing for an existing ${cl.label}`, async function (assert) {
+      test(`it returns no extra error when founder is missing for a ${cl.label} and the mandatory founder rule is relaxed`, async function (assert) {
         const classification = this.store().createRecord(
           'administrative-unit-classification-code',
           cl
@@ -192,7 +192,9 @@ module('Unit | Model | administrative unit', function (hooks) {
           classification,
         });
 
-        const isValid = await model.validate(true);
+        const isValid = await model.validate({
+          relaxMandatoryFoundingOrganization: true,
+        });
 
         assert.false(isValid);
         assert.strictEqual(Object.keys(model.error).length, 2);

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -25,7 +25,7 @@ module('Unit | Model | administrative unit', function (hooks) {
       });
     });
 
-    test("it returns more error when it's PROJECTVERENIGING and expectedEndDate erlier than now", async function (assert) {
+    test("it returns more error when it's PROJECTVERENIGING and expectedEndDate earlier than now", async function (assert) {
       const classification = this.store().createRecord(
         'administrative-unit-classification-code',
         CLASSIFICATION.PROJECTVERENIGING
@@ -47,6 +47,202 @@ module('Unit | Model | administrative unit', function (hooks) {
         hasParticipants: { message: 'Selecteer een optie' },
         isSubOrganizationOf: { message: 'Selecteer een optie' },
         organizationStatus: { message: 'Selecteer een optie' },
+      });
+    });
+
+    [
+      CLASSIFICATION.WELZIJNSVERENIGING,
+      CLASSIFICATION.AUTONOME_VERZORGINGSINSTELLING,
+      CLASSIFICATION.PEVA_MUNICIPALITY,
+      CLASSIFICATION.PEVA_PROVINCE,
+    ].forEach((cl) => {
+      test(`it returns an extra error when founder is missing for ${cl.label} without relaxing the mandatory rule`, async function (assert) {
+        const classification = this.store().createRecord(
+          'administrative-unit-classification-code',
+          cl
+        );
+        const model = this.store().createRecord('administrative-unit', {
+          classification,
+        });
+
+        const isValid = await model.validate();
+
+        assert.false(isValid);
+        assert.strictEqual(Object.keys(model.error).length, 3);
+        assert.propContains(model.error, {
+          name: { message: 'Vul de naam in' },
+          organizationStatus: { message: 'Selecteer een optie' },
+          wasFoundedByOrganizations: { message: 'Selecteer een optie' },
+        });
+      });
+    });
+
+    [
+      CLASSIFICATION.WELZIJNSVERENIGING,
+      CLASSIFICATION.AUTONOME_VERZORGINGSINSTELLING,
+      CLASSIFICATION.PEVA_MUNICIPALITY,
+      CLASSIFICATION.PEVA_PROVINCE,
+    ].forEach((cl) => {
+      test(`it returns an extra error when founder is missing for ${cl.label} when providing wrong argument to relax mandatory`, async function (assert) {
+        const classification = this.store().createRecord(
+          'administrative-unit-classification-code',
+          cl
+        );
+        const model = this.store().createRecord('administrative-unit', {
+          classification,
+        });
+
+        const isValid = await model.validate('notTrue');
+
+        assert.false(isValid);
+        assert.strictEqual(Object.keys(model.error).length, 3);
+        assert.propContains(model.error, {
+          name: { message: 'Vul de naam in' },
+          organizationStatus: { message: 'Selecteer een optie' },
+          wasFoundedByOrganizations: { message: 'Selecteer een optie' },
+        });
+      });
+    });
+
+    [
+      CLASSIFICATION.WELZIJNSVERENIGING,
+      CLASSIFICATION.AUTONOME_VERZORGINGSINSTELLING,
+      CLASSIFICATION.PEVA_MUNICIPALITY,
+      CLASSIFICATION.PEVA_PROVINCE,
+    ].forEach((cl) => {
+      test(`it returns no extra error when founder is provided for a ${cl.label}`, async function (assert) {
+        const classification = this.store().createRecord(
+          'administrative-unit-classification-code',
+          cl
+        );
+        const founder = this.store().createRecord('administrative-unit');
+        const model = this.store().createRecord('administrative-unit', {
+          classification,
+          wasFoundedByOrganizations: [founder],
+        });
+
+        const isValid = await model.validate();
+
+        assert.false(isValid);
+        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.propContains(model.error, {
+          name: { message: 'Vul de naam in' },
+          organizationStatus: { message: 'Selecteer een optie' },
+        });
+      });
+    });
+
+    test(`it returns no extra error when founder is provided for an AGB`, async function (assert) {
+      const classification = this.store().createRecord(
+        'administrative-unit-classification-code',
+        CLASSIFICATION.AGB
+      );
+      const founder = this.store().createRecord('administrative-unit');
+      const model = this.store().createRecord('administrative-unit', {
+        classification,
+        wasFoundedByOrganizations: [founder],
+      });
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 3);
+      assert.propContains(model.error, {
+        name: { message: 'Vul de naam in' },
+        organizationStatus: { message: 'Selecteer een optie' },
+        isSubOrganizationOf: { message: 'Selecteer een optie' },
+      });
+    });
+
+    test(`it returns no extra error when founder is provided for an APB`, async function (assert) {
+      const classification = this.store().createRecord(
+        'administrative-unit-classification-code',
+        CLASSIFICATION.APB
+      );
+      const founder = this.store().createRecord('administrative-unit');
+      const model = this.store().createRecord('administrative-unit', {
+        classification,
+        wasFoundedByOrganizations: [founder],
+      });
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 4);
+      assert.propContains(model.error, {
+        name: { message: 'Vul de naam in' },
+        organizationStatus: { message: 'Selecteer een optie' },
+        isAssociatedWith: { message: 'Selecteer een optie' },
+        isSubOrganizationOf: { message: 'Selecteer een optie' },
+      });
+    });
+
+    [
+      CLASSIFICATION.WELZIJNSVERENIGING,
+      CLASSIFICATION.AUTONOME_VERZORGINGSINSTELLING,
+      CLASSIFICATION.PEVA_MUNICIPALITY,
+      CLASSIFICATION.PEVA_PROVINCE,
+    ].forEach((cl) => {
+      test(`it returns no extra error when founder is missing for an existing ${cl.label}`, async function (assert) {
+        const classification = this.store().createRecord(
+          'administrative-unit-classification-code',
+          cl
+        );
+        const model = this.store().createRecord('administrative-unit', {
+          classification,
+        });
+
+        const isValid = await model.validate(true);
+
+        assert.false(isValid);
+        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.propContains(model.error, {
+          name: { message: 'Vul de naam in' },
+          organizationStatus: { message: 'Selecteer een optie' },
+        });
+      });
+    });
+
+    test('it has no effect to relax the mandatory founder rule for an AGB', async function (assert) {
+      const classification = this.store().createRecord(
+        'administrative-unit-classification-code',
+        CLASSIFICATION.AGB
+      );
+      const model = this.store().createRecord('administrative-unit', {
+        classification,
+      });
+
+      const isValid = await model.validate(true);
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 4);
+      assert.propContains(model.error, {
+        name: { message: 'Vul de naam in' },
+        organizationStatus: { message: 'Selecteer een optie' },
+        wasFoundedByOrganizations: { message: 'Selecteer een optie' },
+        isSubOrganizationOf: { message: 'Selecteer een optie' },
+      });
+    });
+
+    test('it has no effect to relax the mandatory founder rule for an APB', async function (assert) {
+      const classification = this.store().createRecord(
+        'administrative-unit-classification-code',
+        CLASSIFICATION.APB
+      );
+      const model = this.store().createRecord('administrative-unit', {
+        classification,
+      });
+
+      const isValid = await model.validate(true);
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 5);
+      assert.propContains(model.error, {
+        name: { message: 'Vul de naam in' },
+        organizationStatus: { message: 'Selecteer een optie' },
+        isAssociatedWith: { message: 'Selecteer een optie' },
+        wasFoundedByOrganizations: { message: 'Selecteer een optie' },
+        isSubOrganizationOf: { message: 'Selecteer een optie' },
       });
     });
   });


### PR DESCRIPTION
OP-3051
Related to the bugs reported in OP-3046 and OP-3047

While a founding organisation should be mandatory for OCMW associations and PEVAs the available business data is incomplete. Strictly enforcing this rule would thus mean that units lacking a founder at the time of onboarding cannot be edited later on as their validation will fail. This commit relaxes this rule such that a founding organisation is only required when creating a new OCMW association or PEVA via the frontend.