### PR TITLE
Fix change-event resulting organization name

### DIFF
--- a/app/routes/administrative-units/administrative-unit/change-events/details.js
+++ b/app/routes/administrative-units/administrative-unit/change-events/details.js
@@ -28,6 +28,13 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsDetailsRou
       }
     );
 
+    // resolve the first resulting organization here as workaround
+    // the get helper does not work with async relationships in the template
+    // https://github.com/emberjs/ember.js/issues/20510
+    const firstResultingOrganization = (
+      await changeEvent.resultingOrganizations
+    )[0];
+
     let currentChangeEventResult = await findCurrentChangeEventResult(
       administrativeUnit,
       changeEvent
@@ -37,6 +44,7 @@ export default class AdministrativeUnitsAdministrativeUnitChangeEventsDetailsRou
       administrativeUnit,
       changeEvent,
       currentChangeEventResult,
+      firstResultingOrganization,
     };
   }
 }

--- a/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/edit.hbs
@@ -162,7 +162,7 @@
                 <Item>
                   <:label>Resulterende organisatie</:label>
                   <:content>
-                    {{get @model.changeEvent.resultingOrganizations "0.name"}}
+                    {{@model.firstResultingOrganization.name}}
                   </:content>
                 </Item>
                 <Item>

--- a/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/change-events/details/index.hbs
@@ -125,9 +125,9 @@
                   <:content>
                     <AuLink
                       @route="administrative-units.administrative-unit"
-                      @model={{get @model.changeEvent.resultingOrganizations "0.id"}}
+                      @model={{@model.firstResultingOrganization.id}}
                     >
-                      {{get @model.changeEvent.resultingOrganizations "0.name"}}
+                      {{@model.firstResultingOrganization.name}}
                     </AuLink>
                   </:content>
                 </Item>


### PR DESCRIPTION
## Context

The syntax use to replace `firstObject` during update to ember 4.12 : `{{get @model.changeEvent.resultingOrganizations "0.name"}}`

Although, this syntax is describe in `no-array-prototype-extensions` linter documentation it is not working on a promise proxy arrays. https://github.com/emberjs/ember.js/issues/20510

## Proposal

Resolve the firstObject in the route