### PR TITLE
Feature: add alternative names for organisations

### DIFF
--- a/app/components/administrative-unit-select-by-name.js
+++ b/app/components/administrative-unit-select-by-name.js
@@ -12,7 +12,7 @@ export default class AdministrativeUnitSelectByNameComponent extends Component {
     const filter = {};
 
     if (searchParams.trim() !== '') {
-      filter[`:phrase_prefix:legal_name,name`] = searchParams;
+      filter[`:phrase_prefix:legal_name,alternative_name,name`] = searchParams;
     }
 
     filter['classification_id'] = getClassificationIds(

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -75,6 +75,11 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
   }
 
   @action
+  setAlternativeNames(names) {
+    this.model.administrativeUnit.setAlternativeName(names);
+  }
+
+  @action
   setKbo(value) {
     this.model.structuredIdentifierKBO.localId = value;
   }

--- a/app/helpers/help-text.js
+++ b/app/helpers/help-text.js
@@ -12,6 +12,8 @@ const HELP_TEXT = {
     'De naam wordt automatisch ingevuld. Deze naam is gelijk aan de juridische naam. Indien geen juridische naam beschikbaar is, wordt de naam uit KBO ingevuld.',
   legalName:
     'De juridische naam is de naam uit de statuten, decreet of andere juridisch regelgevende teksten of besluiten. Bij het aanmaken van de organisatie wordt deze ingegeven door ABB, daarna verhuist het beheer van deze naam naar de organisatie zelf, via de Contact app.',
+  alternativeNames:
+    'Alternatieve namen kan de afgekorte naam uit statuten, een commerciële en/of een informele naam zijn. Bij het aanmaken van de organisatie wordt deze ingegeven door ABB, daarna verhuist het beheer van deze naam naar de organisatie zelf, via de Contact app.',
 };
 
 export default helper(function helpText([key]) {

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -11,7 +11,7 @@ import {
 export default class OrganizationModel extends AgentModel {
   @attr name;
   @attr legalName;
-  @attr alternativeName;
+  @attr('string-set') alternativeName; // Note: changing to plural breaks stuff
   @attr('date') expectedEndDate;
   @attr purpose;
 
@@ -139,7 +139,7 @@ export default class OrganizationModel extends AgentModel {
       legalName: Joi.string().empty('').required().messages({
         'any.required': 'Vul de juridische naam in',
       }),
-      alternativeName: validateStringOptional(),
+      alternativeName: Joi.array().optional(),
       expectedEndDate: Joi.date().allow(null),
       purpose: validateStringOptional(),
       primarySite: validateBelongsToOptional(),
@@ -169,5 +169,12 @@ export default class OrganizationModel extends AgentModel {
   setAbbName(name) {
     this.name = name;
     this.legalName = name;
+  }
+
+  setAlternativeName(names) {
+    this.alternativeName = names
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s !== '');
   }
 }

--- a/app/routes/administrative-units/index.js
+++ b/app/routes/administrative-units/index.js
@@ -36,7 +36,7 @@ export default class AdministrativeUnitsIndexRoute extends Route {
       let filterType = 'phrase_prefix';
       let name = params.name.trim();
 
-      filter[`:${filterType}:legal_name,name`] = name;
+      filter[`:${filterType}:legal_name,alternative_name,name`] = name;
     }
 
     if (params.identifier) {

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -81,6 +81,25 @@
                     </AuHelpText>
                   </:content>
                 </Item>
+                <Item
+                  @labelFor="administrative-unit-alternative-names"
+                  @required={{false}}
+                >
+                  <:label>Alternatieve naam</:label>
+                  <:content as |hasError|>
+                    <TrimInput
+                      @width="block"
+                      @disabled={{false}}
+                      @value={{@model.administrativeUnit.alternativeName}}
+                      @onUpdate={{this.setAlternativeNames}}
+                      @error={{hasError}}
+                      id="administrative-unit-alternative-names"
+                    />
+                    <AuHelpText>
+                      {{help-text "alternativeNames"}}
+                    </AuHelpText>
+                  </:content>
+                </Item>
                 <Item @labelFor="classification">
                   <:label>Type bestuur</:label>
                   <:content>

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -94,6 +94,14 @@
                   <:label>Juridische naam</:label>
                   <:content>{{@model.administrativeUnit.legalName}}</:content>
                 </Item>
+                {{#if (gt @model.administrativeUnit.alternativeName.length 0)}}
+                  <Item>
+                    <:label>Alternatieve naam</:label>
+                    <:content>
+                      {{@model.administrativeUnit.alternativeName}}
+                    </:content>
+                  </Item>
+                {{/if}}
                 <Item>
                   <:label>Type bestuur</:label>
                   <:content>
@@ -359,6 +367,14 @@
                 <:label>Juridische naam</:label>
                 <:content>{{@model.administrativeUnit.legalName}}</:content>
               </Item>
+              {{#if (gt @model.administrativeUnit.alternativeName.length 0)}}
+                <Item>
+                  <:label>Alternatieve naam</:label>
+                  <:content>
+                    {{@model.administrativeUnit.alternativeName}}
+                  </:content>
+                </Item>
+              {{/if}}
               <Item>
                 <:label>Type bestuur</:label>
                 <:content>

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -72,6 +72,27 @@
               </:content>
             </Item>
             <Item
+              @labelFor="administrative-unit-alternative-names"
+              @required={{false}}
+            >
+              <:label>Alternatieve naam</:label>
+              <:content as |hasError|>
+                <TrimInput
+                  @width="block"
+                  @disabled={{false}}
+                  @value={{@model.administrativeUnit.alternativeName}}
+                  @onUpdate={{fn
+                    (mut @model.administrativeUnit.alternativeName)
+                  }}
+                  @error={{hasError}}
+                  id="administrative-unit-alternative-names"
+                />
+                <AuHelpText>
+                  {{help-text "alternativeNames"}}
+                </AuHelpText>
+              </:content>
+            </Item>
+            <Item
               @labelFor="classification-select"
               @required={{true}}
               @errorMessage={{@model.administrativeUnit.error.classification.message}}

--- a/app/templates/organizations/organization/core-data.hbs
+++ b/app/templates/organizations/organization/core-data.hbs
@@ -20,6 +20,14 @@
               <:label>Juridische naam</:label>
               <:content>{{@model.representativeBody.legalName}}</:content>
             </Item>
+            {{#if (gt @model.representativeBody.alternativeName.length 0)}}
+              <Item>
+                <:label>Alternatieve naam</:label>
+                <:content>
+                  {{@model.representativeBody.alternativeName}}
+                </:content>
+              </Item>
+            {{/if}}
             <Item>
               <:label>Soort eredienst</:label>
               <:content


### PR DESCRIPTION
OP-3000

## Summary
- Added field "Alternatieve naam" to core data views, only visible when at least one alternative name was set
- Extended edit core data and create administrative unit forms with an input field for alternative names. Multiple names should be separated by a comma.
- Added a custom transformation to convert string displayed for alternative names in the forms to an array of strings that can be processed by the backend (and vice versa)
- Inlude the alternative names in the name search (requires a reindex to work)
- Backend [PR](https://github.com/lblod/app-organization-portal/pull/390)