### PR TITLE
Fix sharepoint and kbo reset in administrative-unit edit form

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -222,7 +222,9 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
     this.model.contact.reset();
     this.model.secondaryContact.reset();
     this.model.address.reset();
+    this.model.structuredIdentifierKBO.rollbackAttributes();
     this.model.identifierKBO.reset();
+    this.model.structuredIdentifierSharepoint.rollbackAttributes();
     this.model.identifierSharepoint.reset();
   }
 


### PR DESCRIPTION
Related to OP-3048

KBO and Sharepoint were not correctly reset in administrative-unit edit form controller. 