### PR TITLE
Update ember-data version to 4.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "ember-concurrency": "^2.2.1",
         "ember-config-helper": "^0.1.3",
         "ember-copy": "^2.0.1",
-        "ember-data": "~4.11.3",
+        "ember-data": "~4.12.0",
         "ember-fetch": "^8.1.2",
         "ember-functions-as-helper-polyfill": "^2.0.1",
         "ember-inflector": "^4.0.2",
@@ -2407,103 +2407,157 @@
       }
     },
     "node_modules/@ember-data/adapter": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.11.3.tgz",
-      "integrity": "sha512-G7dbaPnYMW8VYxIT75KAkzax2mkWTs2TYxS7+qbphs6esXpO9Y/iNp5fTqLaACb9JqUypwEA/rlfC7/zkcGbBw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/adapter/-/adapter-4.12.5.tgz",
+      "integrity": "sha512-YWCjBga9h59q3iBqLONxi68AjNZtKmxQ/uB7e8uSv7czOXGQKpzONlTb68jyMJ687qpg0RWebxLBlBU5yPxq1Q==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.11.3",
-        "@ember/edition-utils": "^1.2.0",
+        "@ember-data/private-build-infra": "4.12.5",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/store": "4.11.3",
+        "@ember-data/store": "4.12.5",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       }
     },
-    "node_modules/@ember-data/canary-features": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/canary-features/-/canary-features-4.11.3.tgz",
-      "integrity": "sha512-RTLY2N9t1SXr4e90VBKi+3PIitwjTMBU8BcEhnKovT//sGlywohHq7T36H6nJuITRtki3On9PpbJOhhQZuyAlQ==",
-      "dev": true,
-      "dependencies": {
-        "@embroider/macros": "^1.10.0",
-        "ember-cli-babel": "^7.26.11"
-      },
-      "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
-      }
-    },
     "node_modules/@ember-data/debug": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.11.3.tgz",
-      "integrity": "sha512-3pA5u3qy+pjtwcoyMzs7WijRrSQz5z+Vgn9b5Y4cEOHn8loS9riLCMScnFaQT3HjxQgq+3NkNb52sJafHPzs4Q==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/debug/-/debug-4.12.5.tgz",
+      "integrity": "sha512-IpmZ2ZXhl7NDPd8DH2XNQBzjiwxJHmGbwGFs9IVtZXmOSkk5iCX6v2MkeRBeDjLvUOcZIHNBuHUz66nZJrHNCg==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/private-build-infra": "4.12.5",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
+        "ember-auto-import": "^2.6.1",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
+        "@ember-data/store": "4.12.5",
         "@ember/string": "^3.0.1"
       }
     },
-    "node_modules/@ember-data/model": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.11.3.tgz",
-      "integrity": "sha512-nkDru5TZmOp4J1xp65D1bR3hBJ3u5KhKKfDpWeGnHW2YDCVUdLORRwW7vfrPnnXDIoJij42DwDVCiTY25Xhrqw==",
+    "node_modules/@ember-data/graph": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/graph/-/graph-4.12.5.tgz",
+      "integrity": "sha512-YHvtUeH7h1AIFOlRQeaJrUM9DGkGBkzm6+BoVR2iaEbZKM3A/l0tZD7jUveD2bfdhGPtEf5849mlwKi8T2dIKw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.11.3",
-        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/private-build-infra": "4.12.5",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": "16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember-data/store": "4.12.5"
+      }
+    },
+    "node_modules/@ember-data/json-api": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/json-api/-/json-api-4.12.5.tgz",
+      "integrity": "sha512-L3gLUqXDXwKZnXkWm0U3TW/jiQKdQ9Q74MOxhJEeWmmN19fvKGdHe/oS3FASgdmBpMqkwItACmilDRVXWxbGWA==",
+      "dev": true,
+      "dependencies": {
+        "@ember-data/private-build-infra": "4.12.5",
+        "@ember/edition-utils": "^1.2.0",
+        "@embroider/macros": "^1.10.0",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": "16.* || >= 18.*"
+      },
+      "peerDependencies": {
+        "@ember-data/graph": "4.12.5",
+        "@ember-data/store": "4.12.5"
+      }
+    },
+    "node_modules/@ember-data/legacy-compat": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/legacy-compat/-/legacy-compat-4.12.5.tgz",
+      "integrity": "sha512-/f2aIsgua0UbueYG1G/nXDIfM/DI34b9f0jOgcsrOGULbhNMYAXfWNvr97TPU5swFLd4H/dWM4VG2dq8tBtmxg==",
+      "dev": true,
+      "dependencies": {
+        "@ember-data/private-build-infra": "4.12.5",
+        "@embroider/macros": "^1.10.0",
+        "ember-cli-babel": "^7.26.11"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@ember-data/graph": "4.12.5",
+        "@ember-data/json-api": "4.12.5"
+      },
+      "peerDependenciesMeta": {
+        "@ember-data/graph": {
+          "optional": true
+        },
+        "@ember-data/json-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@ember-data/model": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/model/-/model-4.12.5.tgz",
+      "integrity": "sha512-2+n8tlDSQqrM65u+jGoANQkEzx8dQsMez9EqPZ7Czgv0gtOq9m03H6O3xahqtX/igABwz+2Fcc5o9W4Wv1uWnA==",
+      "dev": true,
+      "dependencies": {
+        "@ember-data/private-build-infra": "4.12.5",
+        "@ember/edition-utils": "^1.2.0",
+        "@embroider/macros": "^1.10.0",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-test-info": "^1.0.0",
-        "ember-compatibility-helpers": "^1.2.6",
-        "inflection": "~2.0.0"
+        "inflection": "~2.0.1"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/record-data": "4.11.3",
-        "@ember-data/store": "4.11.3",
-        "@ember-data/tracking": "4.11.3",
+        "@ember-data/debug": "4.12.5",
+        "@ember-data/graph": "4.12.5",
+        "@ember-data/json-api": "4.12.5",
+        "@ember-data/legacy-compat": "4.12.5",
+        "@ember-data/store": "4.12.5",
+        "@ember-data/tracking": "4.12.5",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       },
       "peerDependenciesMeta": {
-        "@ember-data/record-data": {
+        "@ember-data/debug": {
+          "optional": true
+        },
+        "@ember-data/graph": {
+          "optional": true
+        },
+        "@ember-data/json-api": {
           "optional": true
         }
       }
     },
     "node_modules/@ember-data/private-build-infra": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.11.3.tgz",
-      "integrity": "sha512-bXFQMEegUc+vKn/vD7FmAkq7ECE0okZ2sbtv/0RXqYn7TLk44rvGzpqSUXUowpCaGI/87MmaW8JaZMMdqF9wuw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/private-build-infra/-/private-build-infra-4.12.5.tgz",
+      "integrity": "sha512-FNnyA8+IVylrnnwYR+MGPUushS/X8BEMN4JrrO4Mbrj4Yn10E2gAeKt/MUkk7Gl/HxMw6maxZY8SHoA/NK9XKw==",
       "dev": true,
       "dependencies": {
-        "@babel/core": "^7.20.2",
-        "@babel/plugin-transform-block-scoping": "^7.20.2",
-        "@babel/runtime": "^7.20.1",
-        "@ember-data/canary-features": "4.11.3",
+        "@babel/core": "^7.21.4",
+        "@babel/plugin-transform-block-scoping": "^7.21.0",
+        "@babel/runtime": "^7.21.0",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "babel-import-util": "^1.3.0",
@@ -2522,15 +2576,13 @@
         "ember-cli-string-utils": "^1.1.0",
         "ember-cli-version-checker": "^5.1.2",
         "git-repo-info": "^2.1.1",
-        "glob": "^8.0.3",
+        "glob": "^9.3.4",
         "npm-git-info": "^1.0.3",
-        "rimraf": "^3.0.2",
-        "rsvp": "^4.8.5",
         "semver": "^7.3.8",
         "silent-error": "^1.1.1"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/ansi-styles": {
@@ -2632,19 +2684,18 @@
       "dev": true
     },
     "node_modules/@ember-data/private-build-infra/node_modules/glob": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
-      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^5.0.1",
-        "once": "^1.3.0"
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -2672,15 +2723,27 @@
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@ember-data/private-build-infra/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@ember-data/private-build-infra/node_modules/promise-map-series": {
@@ -2749,15 +2812,6 @@
         "node": "*"
       }
     },
-    "node_modules/@ember-data/private-build-infra/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
     "node_modules/@ember-data/private-build-infra/node_modules/semver": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
@@ -2791,24 +2845,19 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/@ember-data/record-data": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/record-data/-/record-data-4.11.3.tgz",
-      "integrity": "sha512-8NmeEZJ7or354NLZJgibJ1FuhWL70H6G24tGSEIzM8IV7wr6TreIyaWODaW372QwamWYgFIpfnFwWt5MTlY/gw==",
+    "node_modules/@ember-data/request": {
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/request/-/request-4.12.5.tgz",
+      "integrity": "sha512-uxLuQqvjxmiU8ODs5HoiYydnnhpKjBOxxkwSuIMP3Ndb0HlXAqgqSSRMGUzCaNFXYn6KOb7CuDly3OEYYHFlMQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.11.3",
-        "@ember-data/private-build-infra": "4.11.3",
-        "@ember/edition-utils": "^1.2.0",
+        "@ember-data/private-build-infra": "4.12.5",
+        "@ember/test-waiters": "^3.0.2",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
-      },
-      "peerDependencies": {
-        "@ember-data/store": "4.11.3"
+        "node": "16.* || >= 18"
       }
     },
     "node_modules/@ember-data/rfc395-data": {
@@ -2818,68 +2867,75 @@
       "dev": true
     },
     "node_modules/@ember-data/serializer": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.11.3.tgz",
-      "integrity": "sha512-Qnzrowinz14/onQfwd4TPwNG0sMTAwTWE0RajYo2fysF3CKyAua0nIzmFtXKx0CogD7TYd0C5xf6nMjFesT09Q==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/serializer/-/serializer-4.12.5.tgz",
+      "integrity": "sha512-qQzaJTXxfgDcR2YIgOE5iU+51Hn8ghwQxas63GvIBqtnYkbB3i2Fa4OaEJAruU7phlrEYONaKTVOyrTC+pjTKw==",
       "dev": true,
       "dependencies": {
-        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/private-build-infra": "4.12.5",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
         "ember-cli-babel": "^7.26.11",
         "ember-cli-test-info": "^1.0.0"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/store": "4.11.3",
+        "@ember-data/store": "4.12.5",
         "@ember/string": "^3.0.1",
         "ember-inflector": "^4.0.2"
       }
     },
     "node_modules/@ember-data/store": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.11.3.tgz",
-      "integrity": "sha512-ogwWy+VqMpkCGs4n30pzuB2vqv/dJRL6wdV3fdNKpXrDugffjuMPpLBQYF937qztDUZKxmnbWAZe5PbQOz8b1Q==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/store/-/store-4.12.5.tgz",
+      "integrity": "sha512-hpMrOa3+R3jXft7+j1RQl0Jw79rIWZE7TFuA5Z4u11QjlHiXxpOP/0icer8CeRJk1QSWPMedF/TgwZOnYWh4GQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/canary-features": "4.11.3",
-        "@ember-data/private-build-infra": "4.11.3",
+        "@ember-data/private-build-infra": "4.12.5",
         "@embroider/macros": "^1.10.0",
-        "ember-auto-import": "^2.4.3",
         "ember-cached-decorator-polyfill": "^1.0.1",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
-        "@ember-data/model": "4.11.3",
-        "@ember-data/record-data": "4.11.3",
-        "@ember-data/tracking": "4.11.3",
+        "@ember-data/graph": "4.12.5",
+        "@ember-data/json-api": "4.12.5",
+        "@ember-data/legacy-compat": "4.12.5",
+        "@ember-data/model": "4.12.5",
+        "@ember-data/tracking": "4.12.5",
         "@ember/string": "^3.0.1",
         "@glimmer/tracking": "^1.1.2"
       },
       "peerDependenciesMeta": {
-        "@ember-data/model": {
+        "@ember-data/graph": {
           "optional": true
         },
-        "@ember-data/record-data": {
+        "@ember-data/json-api": {
+          "optional": true
+        },
+        "@ember-data/legacy-compat": {
+          "optional": true
+        },
+        "@ember-data/model": {
           "optional": true
         }
       }
     },
     "node_modules/@ember-data/tracking": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.11.3.tgz",
-      "integrity": "sha512-YZxFTMe2TBL8H8/GrnrvP7Wc/uuAijoSyiP2g6TMNRsL1e/3BWDT0EIl+B/5Wji+dchofY8iuMWfpY7VDvPIzA==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/@ember-data/tracking/-/tracking-4.12.5.tgz",
+      "integrity": "sha512-1i69F6cywzsHZGolJ+W0NelJH7AToICXyuqdH4R9mgzoOD6e3wxY+MBXhB/KoTxoa508G0vYozQ4weea3E/oyw==",
       "dev": true,
       "dependencies": {
+        "@ember-data/private-build-infra": "4.12.5",
+        "@embroider/macros": "^1.10.0",
         "ember-cli-babel": "^7.26.11"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": "16.* || >= 18"
       }
     },
     "node_modules/@ember-decorators/utils": {
@@ -15939,29 +15995,32 @@
       }
     },
     "node_modules/ember-data": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.11.3.tgz",
-      "integrity": "sha512-7vir6Re3M3M6yJoCHy6UxEg3oSY1JEnsuTByY3lJquWPaUamn7qbPQvNr16Tqh8EKrt+e/+X26czFm4kRGhpVg==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/ember-data/-/ember-data-4.12.5.tgz",
+      "integrity": "sha512-5q0m0qFdbur3eFk2/iT1GEGxBUOnwbDD0Gk6sWLiVGL2NLZw1wH6Spo36RqClx62ov2vlo9DytVmKbOu224WaQ==",
       "dev": true,
       "dependencies": {
-        "@ember-data/adapter": "4.11.3",
-        "@ember-data/debug": "4.11.3",
-        "@ember-data/model": "4.11.3",
-        "@ember-data/private-build-infra": "4.11.3",
-        "@ember-data/record-data": "4.11.3",
-        "@ember-data/serializer": "4.11.3",
-        "@ember-data/store": "4.11.3",
-        "@ember-data/tracking": "4.11.3",
+        "@ember-data/adapter": "4.12.5",
+        "@ember-data/debug": "4.12.5",
+        "@ember-data/graph": "4.12.5",
+        "@ember-data/json-api": "4.12.5",
+        "@ember-data/legacy-compat": "4.12.5",
+        "@ember-data/model": "4.12.5",
+        "@ember-data/private-build-infra": "4.12.5",
+        "@ember-data/request": "4.12.5",
+        "@ember-data/serializer": "4.12.5",
+        "@ember-data/store": "4.12.5",
+        "@ember-data/tracking": "4.12.5",
         "@ember/edition-utils": "^1.2.0",
         "@embroider/macros": "^1.10.0",
         "@glimmer/env": "^0.1.7",
         "broccoli-merge-trees": "^4.2.0",
-        "ember-auto-import": "^2.4.3",
+        "ember-auto-import": "^2.6.1",
         "ember-cli-babel": "^7.26.11",
         "ember-inflector": "^4.0.2"
       },
       "engines": {
-        "node": "^14.8.0 || 16.* || >= 18.*"
+        "node": "16.* || >= 18.*"
       },
       "peerDependencies": {
         "@ember/string": "^3.0.1"
@@ -30125,6 +30184,40 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.0.tgz",
+      "integrity": "sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "ember-concurrency": "^2.2.1",
     "ember-config-helper": "^0.1.3",
     "ember-copy": "^2.0.1",
-    "ember-data": "~4.11.3",
+    "ember-data": "~4.12.0",
     "ember-fetch": "^8.1.2",
     "ember-functions-as-helper-polyfill": "^2.0.1",
     "ember-inflector": "^4.0.2",


### PR DESCRIPTION
Related to OP-3065

KBO-number shouldn't be checked if the value hasn't change. https://github.com/lblod/frontend-organization-portal/blob/development/app/models/identifier.js#L41-L44
The previous ember update introduce a bug in `changedAttributes` result after saving https://github.com/emberjs/data/issues/8329

Bump to ember-data 4.12.5 fixes the problem. 