### PR TITLE
Fix: correctly set alternative names when creating new administrative units

### DIFF
--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -99,6 +99,11 @@ export default class AdministrativeUnitsNewController extends Controller {
   }
 
   @action
+  setAlternativeNames(names) {
+    this.model.administrativeUnit.setAlternativeName(names);
+  }
+
+  @action
   setHasParticipants(units) {
     this.model.administrativeUnit.hasParticipants = units;
   }

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -81,9 +81,7 @@
                   @width="block"
                   @disabled={{false}}
                   @value={{@model.administrativeUnit.alternativeName}}
-                  @onUpdate={{fn
-                    (mut @model.administrativeUnit.alternativeName)
-                  }}
+                  @onUpdate={{this.setAlternativeNames}}
                   @error={{hasError}}
                   id="administrative-unit-alternative-names"
                 />


### PR DESCRIPTION
OP-3099

This bug reported two things
- Validation error during creation: this was fixed by correcting the form to correctly set the new alternative names
- An error appeared in the console when trying to edit "A.S.Z. Autonome Verzorgingsinstelling". The underlying cause was that  this organisation had as alternative name the **numeric value** 1 saved in the triplestore instead of a string literal. But I was unable to replicate this situation for another organisation via the frontend. The only way I was able to somewhat replicate it was by directly inserting a numeric value into the triplestore using the SPARQL endpoint. I ended up removing the faulty value for this specific organisation in the DEV environment,via the frontend by clearing its alternative name field and saving the form. (The current alternative name "1" is the result of testing whether I could retrigger the error to occur.)