### PR TITLE
fix: make relation between Person and AgentInPosition polymorphic

### DIFF
--- a/app/models/agent-in-position.js
+++ b/app/models/agent-in-position.js
@@ -8,6 +8,8 @@ export default class AgentInPositionModel extends AgentModel {
   @belongsTo('person', {
     inverse: 'agentsInPosition',
     async: true,
+    polymorphic: true,
+    as: 'agent-in-position',
   })
   person;
 

--- a/app/models/person.js
+++ b/app/models/person.js
@@ -9,6 +9,8 @@ export default class PersonModel extends AgentModel {
   @hasMany('agent-in-position', {
     inverse: 'person',
     async: true,
+    polymorphic: true,
+    as: 'person',
   })
   agentsInPosition;
 


### PR DESCRIPTION
## Summary
The update in #589 introduced a bug where the frontend crashed upon opening a page concernig people. For example, opening the "Leidinggevenden" tab for the municipality of Leuven resulted in the following error:
```
Error: The schema for the relationship 'functionary.person' is not configured to satisfy 'agent-in-position' and thus cannot utilize the 'agent-in-position.person' relationship to connect with 'person.agentsInPosition'

If using this relationship in a polymorphic manner is desired, the relationships schema definition for 'functionary' should include:

{
  person: {
    name: 'person',
    type: 'person',
    kind: 'belongsTo',
    options: {
      as: 'undefined', <---- should be 'agent-in-position'
      async: true,
      polymorphic: false,
      inverse: 'agentsInPosition'
    }
  }
}

 and the relationships schema definition for 'person' should include:

{
  agentsInPosition: {
    name: 'agentsInPosition',
    type: 'agent-in-position',
    kind: 'hasMany',
    options: {
      as: 'undefined', <---- should be 'person'
      async: true,
      polymorphic: false, <---- should be true
      inverse: 'person'
    }
  }
}
```
Similar errors occurred for other pages containing people's positions, such as ministers ("Bedienaren") for worship services.
Note, so far the errors have only occurred on local dev environments, not on DEV itself.

## Proposed solution
Explicitly specify set `polymorphic` option for the relationship between `Person` and `AgentInPosition`.