### PR TITLE
Fix: display "Naam" as label for the name field for some types of sites

### DIFF
--- a/app/templates/administrative-units/administrative-unit/sites/new.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/new.hbs
@@ -51,18 +51,16 @@
                   </:content>
                 </Item>
                 {{#if this.model.site.isOtherSite}}
-                  <Item
-                    @labelFor="site-type-name"
-                  >
-                    <:label>Name</:label>
+                  <Item @labelFor="site-type-name">
+                    <:label>Naam</:label>
                     <:content>
-                     <AuInput
-                      @selected={{this.model.site.siteTypeName}}
-                      {{on "input" this.setSiteTypeName}}
-                      value={{this.model.site.siteTypeName}}
-                      @width="block"
-                      maxlength="50"
-                     />
+                      <AuInput
+                        @selected={{this.model.site.siteTypeName}}
+                        {{on "input" this.setSiteTypeName}}
+                        value={{this.model.site.siteTypeName}}
+                        @width="block"
+                        maxlength="50"
+                      />
                     </:content>
                   </Item>
                 {{/if}}

--- a/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/edit.hbs
@@ -59,7 +59,7 @@
                 </Item>
                 {{#if this.model.site.isOtherSite}}
                   <Item @labelFor="site-type-name">
-                    <:label>Name</:label>
+                    <:label>Naam</:label>
                     <:content>
                       <AuInput
                         @selected={{this.model.site.siteTypeName}}

--- a/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/sites/site/index.hbs
@@ -33,7 +33,7 @@
             </Item>
             {{#if (and @model.site.isOtherSite @model.site.siteTypeName)}}
               <Item>
-                <:label>Name</:label>
+                <:label>Naam</:label>
                 <:content>{{@model.site.siteTypeName}}</:content>
               </Item>
             {{/if}}


### PR DESCRIPTION
Sites of type "Andere vestiging" (Other site) can have an optional name. The label shown for this field was the English "Name" instead of the Dutch "Naam".