### PR TITLE
Fix: explicitly copy legal and alternative names when creating new units

### DIFF
--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -252,6 +252,8 @@ export default class AdministrativeUnitsNewController extends Controller {
 
 function copyAdministrativeUnitData(newAdministrativeUnit, administrativeUnit) {
   newAdministrativeUnit.name = administrativeUnit.name;
+  newAdministrativeUnit.legalName = administrativeUnit.legalName;
+  newAdministrativeUnit.alternativeName = administrativeUnit.alternativeName;
   newAdministrativeUnit.recognizedWorshipType =
     administrativeUnit.recognizedWorshipType;
   newAdministrativeUnit.classification = administrativeUnit.classification;


### PR DESCRIPTION
OP-3129

The juridical name and alternative names were not explicitly copied to the `newAdministrativeUnit` object that would eventually be saved. Consequently, these names were lost upon saving a worship administrative unit. For non-worship administrative units this did not occur because the created record was reused.