### PR TITLE
Fix: Validate Sharepoint identifier only when modified

### DIFF
--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -64,7 +64,10 @@ export default class IdentifierModel extends AbstractValidationModel {
 
           if (this.idName === ID_NAME.SHAREPOINT) {
             // SharePoint must be empty or digits
-            if (localId && !localId.match(/^\d+$/)) {
+            const changedAttributes = (
+              await this.structuredIdentifier
+            ).changedAttributes();
+            if (changedAttributes?.localId && !localId.match(/^\d+$/)) {
               return helpers.message(
                 'De SharePoint identificator mag enkel cijfers bevatten'
               );

--- a/tests/unit/models/identifier-test.js
+++ b/tests/unit/models/identifier-test.js
@@ -191,7 +191,7 @@ module('Unit | Model | identifier', function (hooks) {
         const structuredIdentifier = this.store().createRecord(
           'structured-identifier',
           {
-            localId: '123',
+            localId: '123abc',
           }
         );
         const model = this.store().createRecord('identifier', {

--- a/tests/unit/models/identifier-test.js
+++ b/tests/unit/models/identifier-test.js
@@ -187,6 +187,28 @@ module('Unit | Model | identifier', function (hooks) {
         assert.true(isValid);
       });
 
+      test('it does not validate when localId was not changed', async function (assert) {
+        const structuredIdentifier = this.store().createRecord(
+          'structured-identifier',
+          {
+            localId: '123',
+          }
+        );
+        const model = this.store().createRecord('identifier', {
+          idName: 'SharePoint identificator',
+          structuredIdentifier,
+        });
+        const stub = sinon.stub(structuredIdentifier, 'changedAttributes');
+        stub.returns({});
+
+        const isValid = await model.validate();
+
+        stub.restore();
+
+        assert.true(isValid);
+        assert.strictEqual(model.error, undefined);
+      });
+
       test('it returns error when localId is not a number', async function (assert) {
         const structuredIdentifier = this.store().createRecord(
           'structured-identifier',


### PR DESCRIPTION
OP-3134