### PR TITLE
Do not trigger validation on empty SharePoint identifier

### DIFF
--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -195,9 +195,13 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
       yield structuredIdentifierKBO.save();
       yield identifierKBO.save();
 
-      structuredIdentifierSharepoint = setEmptyStringsToNull(
-        structuredIdentifierSharepoint
-      );
+      // FIXME: If uncommented existing SharePoint identifier is not removed
+      // when user removes the value in the form. Commenting it a quick, dirty
+      // fix because it overwrites the previous value with an empty string
+      // instead of leaving it untouched.
+      // structuredIdentifierSharepoint = setEmptyStringsToNull(
+      //   structuredIdentifierSharepoint,
+      // );
       yield structuredIdentifierSharepoint.save();
       yield identifierSharepoint.save();
 

--- a/app/models/identifier.js
+++ b/app/models/identifier.js
@@ -67,7 +67,7 @@ export default class IdentifierModel extends AbstractValidationModel {
             const changedAttributes = (
               await this.structuredIdentifier
             ).changedAttributes();
-            if (changedAttributes?.localId && !localId.match(/^\d+$/)) {
+            if (changedAttributes?.localId && !localId.match(/^\d*$/)) {
               return helpers.message(
                 'De SharePoint identificator mag enkel cijfers bevatten'
               );

--- a/tests/unit/models/identifier-test.js
+++ b/tests/unit/models/identifier-test.js
@@ -230,6 +230,40 @@ module('Unit | Model | identifier', function (hooks) {
           'De SharePoint identificator mag enkel cijfers bevatten'
         );
       });
+
+      test('it does not return an error when localId is an empty string', async function (assert) {
+        const structuredIdentifier = this.store().createRecord(
+          'structured-identifier',
+          {
+            localId: '',
+          }
+        );
+        const model = this.store().createRecord('identifier', {
+          idName: 'SharePoint identificator',
+          structuredIdentifier,
+        });
+
+        const isValid = await model.validate();
+
+        assert.true(isValid);
+      });
+
+      test('it does not return an error when localId is undefined', async function (assert) {
+        const structuredIdentifier = this.store().createRecord(
+          'structured-identifier',
+          {
+            localId: undefined,
+          }
+        );
+        const model = this.store().createRecord('identifier', {
+          idName: 'SharePoint identificator',
+          structuredIdentifier,
+        });
+
+        const isValid = await model.validate();
+
+        assert.true(isValid);
+      });
     });
   });
 });


### PR DESCRIPTION
OP-3147

Note: the second commit is a quick fix for another bug encountered in the process of solving the original one. I think a cleaner solution for that requires more in-depth changes.