### PR TITLE
fix: moved worship classification checks to administrative unit model

### DIFF
--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -261,4 +261,20 @@ export default class AdministrativeUnitModel extends OrganizationModel {
       this.isRepresentativeBody
     );
   }
+
+  // NOTE: the following worship-related functions have to be placed here
+  // instead of their corresponding models. The new organization form works
+  // based on an administrative unit record and does not show the correct
+  // fields if these functions are placed in the more specific models.
+  get isWorshipAdministrativeUnit() {
+    return this.isWorshipService || this.isCentralWorshipService;
+  }
+
+  get isWorshipService() {
+    return this._hasClassificationId(WorshipServiceCodeList);
+  }
+
+  get isCentralWorshipService() {
+    return this._hasClassificationId(CentralWorshipServiceCodeList);
+  }
 }

--- a/app/models/central-worship-service.js
+++ b/app/models/central-worship-service.js
@@ -1,8 +1,3 @@
 import WorshipAdministrativeUnitModel from './worship-administrative-unit';
-import { CentralWorshipServiceCodeList } from '../constants/Classification';
 
-export default class CentralWorshipServiceModel extends WorshipAdministrativeUnitModel {
-  get isCentralWorshipService() {
-    return this._hasClassificationId(CentralWorshipServiceCodeList);
-  }
-}
+export default class CentralWorshipServiceModel extends WorshipAdministrativeUnitModel {}

--- a/app/models/worship-administrative-unit.js
+++ b/app/models/worship-administrative-unit.js
@@ -5,6 +5,7 @@ import {
   validateRequiredWhenClassificationId,
 } from '../validators/schema';
 import { WorshipServiceCodeList } from '../constants/Classification';
+import { WITH_CENTRAL_WORSHIP_SERVICE } from './recognized-worship-type';
 
 export default class WorshipAdministrativeUnitModel extends AdministrativeUnitModel {
   @belongsTo('recognized-worship-type', {
@@ -40,7 +41,14 @@ export default class WorshipAdministrativeUnitModel extends AdministrativeUnitMo
     });
   }
 
-  get isWorshipAdministrativeUnit() {
-    return this.isWorshipService || this.isCentralWorshipService;
+  get hasCentralWorshipService() {
+    return (
+      this.isWorshipService &&
+      this.#hasRecognizedWorshipTypeId(WITH_CENTRAL_WORSHIP_SERVICE)
+    );
+  }
+
+  #hasRecognizedWorshipTypeId(classificationIds) {
+    return classificationIds.includes(this.classification?.get('id'));
   }
 }

--- a/app/models/worship-service.js
+++ b/app/models/worship-service.js
@@ -2,8 +2,6 @@ import { attr } from '@ember-data/model';
 import Joi from 'joi';
 import WorshipAdministrativeUnitModel from './worship-administrative-unit';
 import { validateStringOptional } from '../validators/schema';
-import { WorshipServiceCodeList } from '../constants/Classification';
-import { WITH_CENTRAL_WORSHIP_SERVICE } from './recognized-worship-type';
 
 export default class WorshipServiceModel extends WorshipAdministrativeUnitModel {
   @attr denomination;
@@ -22,20 +20,5 @@ export default class WorshipServiceModel extends WorshipAdministrativeUnitModel 
       denomination: validateStringOptional(),
       crossBorder: Joi.boolean(),
     });
-  }
-
-  get isWorshipService() {
-    return this._hasClassificationId(WorshipServiceCodeList);
-  }
-
-  get hasCentralWorshipService() {
-    return (
-      this.isWorshipService &&
-      this.#hasRecognizedWorshipTypeId(WITH_CENTRAL_WORSHIP_SERVICE)
-    );
-  }
-
-  #hasRecognizedWorshipTypeId(classificationIds) {
-    return classificationIds.includes(this.classification?.get('id'));
   }
 }

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -285,25 +285,6 @@ module('Unit | Model | administrative unit', function (hooks) {
       });
     });
 
-    [
-      [CLASSIFICATION.WORSHIP_SERVICE, 'isWorshipService'],
-      [CLASSIFICATION.CENTRAL_WORSHIP_SERVICE, 'isCentralWorshipService'],
-      [CLASSIFICATION.REPRESENTATIVE_BODY, 'isRepresentativeBody'],
-    ].forEach(([cl, func]) => {
-      test(`it should return false for ${cl.label}`, async function (assert) {
-        const classification = this.store().createRecord(
-          'administrative-unit-classification-code',
-          cl
-        );
-        const model = this.store().createRecord('administrative-unit', {
-          classification,
-        });
-
-        const result = model[func];
-        assert.notOk(result);
-      });
-    });
-
     Object.keys(CLASSIFICATION).forEach((cl) => {
       test(`it should return false for whether ${cl.label} has a central worship service`, async function (assert) {
         const classification = this.store().createRecord(

--- a/tests/unit/models/central-worship-service-test.js
+++ b/tests/unit/models/central-worship-service-test.js
@@ -40,23 +40,5 @@ module('Unit | Model | central worship service', function (hooks) {
       const result = model.isCentralWorshipService;
       assert.true(result);
     });
-
-    [
-      [CLASSIFICATION.WORSHIP_SERVICE, 'isWorshipService'],
-      [CLASSIFICATION.REPRESENTATIVE_BODY, 'isRepresentativeBody'],
-    ].forEach(([cl, func]) => {
-      test(`it should return false for ${cl.label}`, async function (assert) {
-        const classification = this.store().createRecord(
-          'administrative-unit-classification-code',
-          cl
-        );
-        const model = this.store().createRecord('central-worship-service', {
-          classification,
-        });
-
-        const result = model[func];
-        assert.notOk(result);
-      });
-    });
   });
 });

--- a/tests/unit/models/worship-administrative-unit-test.js
+++ b/tests/unit/models/worship-administrative-unit-test.js
@@ -65,24 +65,5 @@ module('Unit | Model | worship administrative unit', function (hooks) {
       const result = model.isWorshipAdministrativeUnit;
       assert.notOk(result);
     });
-
-    [
-      CLASSIFICATION.CENTRAL_WORSHIP_SERVICE,
-      CLASSIFICATION.REPRESENTATIVE_BODY,
-      CLASSIFICATION.WORSHIP_SERVICE,
-    ].forEach((cl) => {
-      test(`it should return false for a ${cl.label}`, async function (assert) {
-        const classification = this.store().createRecord(
-          'administrative-unit-classification-code',
-          cl
-        );
-        const model = this.store().createRecord('worship-administrative-unit', {
-          classification,
-        });
-
-        const result = model.isWorshipAdministrativeUnit;
-        assert.notOk(result);
-      });
-    });
   });
 });

--- a/tests/unit/models/worship-service-test.js
+++ b/tests/unit/models/worship-service-test.js
@@ -41,22 +41,17 @@ module('Unit | Model | worship service', function (hooks) {
       assert.true(result);
     });
 
-    [
-      [CLASSIFICATION.CENTRAL_WORSHIP_SERVICE, 'isCentralWorshipService'],
-      [CLASSIFICATION.REPRESENTATIVE_BODY, 'isRepresentativeBody'],
-    ].forEach(([cl, func]) => {
-      test(`it should return false for ${cl.label}`, async function (assert) {
-        const classification = this.store().createRecord(
-          'administrative-unit-classification-code',
-          cl
-        );
-        const model = this.store().createRecord('worship-service', {
-          classification,
-        });
-
-        const result = model[func];
-        assert.notOk(result);
+    test(`it should return false for a representative body`, async function (assert) {
+      const classification = this.store().createRecord(
+        'administrative-unit-classification-code',
+        CLASSIFICATION.REPRESENTATIVE_BODY
+      );
+      const model = this.store().createRecord('worship-service', {
+        classification,
       });
+
+      const result = model.isRepresentativeBody;
+      assert.notOk(result);
     });
   });
 });


### PR DESCRIPTION
Bug reported by @cecemel that prevents the creation of new worship
services. Also reported by the testers (OP-3178) shortly after the initial
report.

The form for new organizations uses an administrative-unit record. This means
that if the functions are placed in the more specific models they cannot be
correctly used when deciding which fields to show.

More concretely, the fields for "Soort eredienst", "Strekking", and
"Grensoverschrijdend" were not shown when creating worship services. The
get-functions used to trigger displaying these fields were defined in the
worship service model and therefore not available in the form.


Note: While fixing this bug I noticed a similar problem with the "Centraal
bestuur" field that is never shown. This bug was introduced in earlier
refactoring and affects more forms. This will be fixed in a follow-up PR.