### PR TITLE
fix: display field for "Centraal bestuur" in appropriate forms

### DIFF
--- a/app/models/worship-administrative-unit.js
+++ b/app/models/worship-administrative-unit.js
@@ -48,7 +48,9 @@ export default class WorshipAdministrativeUnitModel extends AdministrativeUnitMo
     );
   }
 
-  #hasRecognizedWorshipTypeId(classificationIds) {
-    return classificationIds.includes(this.classification?.get('id'));
+  #hasRecognizedWorshipTypeId(recognizedWorshipTypeIds) {
+    return recognizedWorshipTypeIds.includes(
+      this.recognizedWorshipType?.get('id')
+    );
   }
 }

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -279,7 +279,7 @@
       <:title>Primaire contactgegevens</:title>
     </Site::ContactEditCard>
 
-    {{#if this.model.administrativeUnit.classification}}
+    {{#if @model.administrativeUnit.classification}}
       <EditCard @containsRequiredFields={{true}}>
         <:title>Gerelateerde organisaties</:title>
         <:card as |Card|>
@@ -299,7 +299,32 @@
                       />
                     </:content>
                   </Item>
-                {{else if @model.administrativeUnit.hasCentralWorshipService}}
+                {{/if}}
+                {{! FIXME: dirty hack to have the field displayed in the right
+                circumstances. This enables the field for worship services of
+                worship type Roman-Catholic, Islamic, and Orthodox. This should
+                become unneccessary when the organization creation functionality
+                stops defaulting to plain administrative units (OP-3183).}}
+                {{#if
+                  (and
+                    @model.administrativeUnit.isWorshipService
+                    @model.administrativeUnit.recognizedWorshipType
+                    (or
+                      (eq
+                        @model.administrativeUnit.recognizedWorshipType.id
+                        "b13d1d623626bc1ee75c7d20bc60e3c0"
+                      )
+                      (eq
+                        @model.administrativeUnit.recognizedWorshipType.id
+                        "9d8bd472a00bf0a5c7b7186606365a52"
+                      )
+                      (eq
+                        @model.administrativeUnit.recognizedWorshipType.id
+                        "84bcd6896f575bae4857ff8d2764bed8"
+                      )
+                    )
+                  )
+                }}
                   <Item
                     @labelFor="related-central-worship-service"
                     @required={{false}}


### PR DESCRIPTION
OP-3177

## Problem

The field "Centraal bestuur" was previously never shown in the necessary forms (create new organization and edit related organizations) as a consequence of two issues:

1. The `hasRecognizedWorshipTypeId` function in `worship-adminsitrative-unit` contained a bug in that it used the `classification` relation instead of the `recognizedWorshipType` relation.
2. The template for the new organizations form operates on a plain `administrative-unit` model instance and has no access to the `hasCentralWorshipService` getter in `worship-administrative-unit`.

## Solution

1. The first problem was simply fixed by correcting the implementation of the function. (commit 135dca9d)
2. The second problem was worked around by explicitly implementing the necessary check in the template. (commit 60a62397) As commented in the code this is a temporary hack so that we have a correctly functioning frontend again. A proper solution requires more in-depth changes in the functionality for organization creation (which are also necessary for OP-3183 which was discovered while looking into this issue and its possible solutions.)