### PR TITLE
Add message when kboOrganization is missing

### DIFF
--- a/app/components/kbo-organization/data-card.hbs
+++ b/app/components/kbo-organization/data-card.hbs
@@ -1,80 +1,86 @@
-<DataCard>
-  <:title>Bestuurseenheid</:title>
-  <:card as |Card|>
-    <Card.Columns>
-      <:left as |Item|>
-        <Item>
-          <:label>Naam</:label>
-          <:content>
-            {{@kboOrganization.legalName}}
-          </:content>
-        </Item>
-        <Item>
-          <:label>Commerciële naam</:label>
-          <:content>
-            {{@kboOrganization.name}}
-          </:content>
-        </Item>
+{{#if @kboOrganization}}
+  <DataCard>
+    <:title>Bestuurseenheid</:title>
+    <:card as |Card|>
+      <Card.Columns>
+        <:left as |Item|>
+          <Item>
+            <:label>Naam</:label>
+            <:content>
+              {{@kboOrganization.legalName}}
+            </:content>
+          </Item>
+          <Item>
+            <:label>Commerciële naam</:label>
+            <:content>
+              {{@kboOrganization.name}}
+            </:content>
+          </Item>
 
-        <Item>
-          <:label>Afgekorte naam</:label>
-          <:content>
-            {{@kboOrganization.alternativeName}}
-          </:content>
-        </Item>
+          <Item>
+            <:label>Afgekorte naam</:label>
+            <:content>
+              {{@kboOrganization.alternativeName}}
+            </:content>
+          </Item>
 
-        <Item>
-          <:label>Rechtsvorm</:label>
-          <:content>
-            {{@kboOrganization.rechtsvorm}}
-          </:content>
-        </Item>
-      </:left>
-      <:right as |Item|>
-        <Item>
-          <:label>Status</:label>
-          <:content>
-            <OrganizationStatus
-              @id={{@kboOrganization.organizationStatus.id}}
-              @label={{@kboOrganization.organizationStatus.label}}
-            />
-          </:content>
-        </Item>
+          <Item>
+            <:label>Rechtsvorm</:label>
+            <:content>
+              {{@kboOrganization.rechtsvorm}}
+            </:content>
+          </Item>
+        </:left>
+        <:right as |Item|>
+          <Item>
+            <:label>Status</:label>
+            <:content>
+              <OrganizationStatus
+                @id={{@kboOrganization.organizationStatus.id}}
+                @label={{@kboOrganization.organizationStatus.label}}
+              />
+            </:content>
+          </Item>
 
-        <Item>
-          <:label>Begindatum</:label>
-          <:content>
-            {{date-format @kboOrganization.startDate}}
-          </:content>
-        </Item>
+          <Item>
+            <:label>Begindatum</:label>
+            <:content>
+              {{date-format @kboOrganization.startDate}}
+            </:content>
+          </Item>
 
-        <Item>
-          <:label>Ondernemingsnummer</:label>
-          <:content>
-            {{#each @kboOrganization.identifiers as |identifier|}}
+          <Item>
+            <:label>Ondernemingsnummer</:label>
+            <:content>
+              {{#each @kboOrganization.identifiers as |identifier|}}
                 {{kbo-format identifier.structuredIdentifier.localId}}
-            {{/each}}
-          </:content>
-        </Item>
-        <Item>
-          <:label>Website KBO</:label>
-          <:content>
-            <AuLinkExternal
-              href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{@kboIdentifier.structuredIdentifier.localId}}"
-            >
-              Link to page (externe link)
-            </AuLinkExternal>
-          </:content>
-        </Item>
-      </:right>
-    </Card.Columns>
-  </:card>
-</DataCard>
-<Site::ContactDataCard
-  @address={{@kboContact.contactAddress}}
-  @primaryContact={{@kboContact}}
->
-  <:title>
-    Maatschappelijke zetel
-  </:title>
-</Site::ContactDataCard>
+              {{/each}}
+            </:content>
+          </Item>
+          <Item>
+            <:label>Website KBO</:label>
+            <:content>
+              <AuLinkExternal
+                href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{@kboIdentifier.structuredIdentifier.localId}}"
+              >
+                Link to page (externe link)
+              </AuLinkExternal>
+            </:content>
+          </Item>
+        </:right>
+      </Card.Columns>
+    </:card>
+  </DataCard>
+  <Site::ContactDataCard
+    @address={{@kboContact.contactAddress}}
+    @primaryContact={{@kboContact}}
+  >
+    <:title>
+      Maatschappelijke zetel
+    </:title>
+  </Site::ContactDataCard>
+{{else}}
+  <AuAlert @skin="warning" @size="tiny">
+    <p>{{if @kboIdentifier this.noKboOrganizationMessage this.noKboMessage}}</p>
+  </AuAlert>
+{{/if}}

--- a/app/components/kbo-organization/data-card.js
+++ b/app/components/kbo-organization/data-card.js
@@ -1,0 +1,8 @@
+import Component from '@glimmer/component';
+
+export default class DataCardComponent extends Component {
+  noKboMessage =
+    'Het KBO nummer is niet ingevuld. Hierdoor kunnen we de KBO gegevens niet tonen.';
+  noKboOrganizationMessage =
+    'De KBO gegevens van deze organisatie kunnen we niet tonen omdat deze momenteel niet beschikbaar zijn in onze bron Organisatieregister Wegwijs.';
+}


### PR DESCRIPTION
## Before 

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/66c1fd4a-400c-4163-a8ac-632511d5214c)

## After

### Use case 1: KBO number is missing

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/4b163bbe-d6e6-4d1b-b0ce-a9056bd7512b)

###  Use case 2: KBO is not missing, but there is no information in Wegwijs

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/f45190b3-9b31-428a-91af-9c0ab001b13d)
