### PR TITLE
Fix Missing kbo number message

### DIFF
--- a/app/components/kbo-organization/data-card.hbs
+++ b/app/components/kbo-organization/data-card.hbs
@@ -61,7 +61,7 @@
             <:label>Website KBO</:label>
             <:content>
               <AuLinkExternal
-                href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{@kboIdentifier.structuredIdentifier.localId}}"
+                href="https://kbopub.economie.fgov.be/kbopub/zoeknummerform.html?nummer={{@kboNumber}}"
               >
                 Link to page (externe link)
               </AuLinkExternal>
@@ -81,6 +81,6 @@
   </Site::ContactDataCard>
 {{else}}
   <AuAlert @skin="warning" @size="tiny">
-    <p>{{if @kboIdentifier this.noKboOrganizationMessage this.noKboMessage}}</p>
+    <p>{{if @kboNumber this.noKboOrganizationMessage this.noKboMessage}}</p>
   </AuAlert>
 {{/if}}

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -283,7 +283,7 @@
     {{else}}
       <KboOrganization::DataCard
         @kboOrganization={{@model.kboOrganization}}
-        @kboIdentifier={{this.kboIdentifier}}
+        @kboNumber={{this.kboIdentifier.structuredIdentifier.localId}}
         @kboContact={{@model.kboContact}}
       />
     {{/if}}

--- a/app/templates/organizations/organization/core-data.hbs
+++ b/app/templates/organizations/organization/core-data.hbs
@@ -181,7 +181,7 @@
     {{else}}
       <KboOrganization::DataCard
         @kboOrganization={{@model.kboOrganization}}
-        @kboIdentifier={{this.kboIdentifier}}
+        @kboNumber={{this.kboIdentifier.structuredIdentifier.localId}}
         @kboContact={{@model.kboContact}}
       />
     {{/if}}


### PR DESCRIPTION
Related to OP-3220

Fix the warning message displays when the organization has a KBO Identifier but no `localId` value. 

## Before

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/b21367f4-a332-46be-ac68-9ebfb43f8db1)

## After

![image](https://github.com/lblod/frontend-organization-portal/assets/3050307/2001ccbb-cefc-4aab-991e-afdc54240628)
