### PR TITLE
Add missing `representative-body-classification-codes` model

### DIFF
--- a/app/models/representative-body-classification-code.js
+++ b/app/models/representative-body-classification-code.js
@@ -1,0 +1,3 @@
+import OrganizationClassificationCodeModel from './organization-classification-code';
+
+export default class RepresentativeBodyClassificationCodeModel extends OrganizationClassificationCodeModel {}


### PR DESCRIPTION
Related to OP-3229

## Context 

The representative body classification codes was recently fixed in the triplestore by https://github.com/lblod/app-organization-portal/pull/412

As a side effect, a code typed `representative-body-classification-codes` is part of `/organization-classification-codes` response. The app is complaining because the model is missing. 

## Fix

Adding the missing model. 