### PR TITLE
fix: correctly update change event decisions after editing

### DIFF
--- a/app/controllers/organizations/organization/change-events/details/edit.js
+++ b/app/controllers/organizations/organization/change-events/details/edit.js
@@ -44,9 +44,10 @@ export default class OrganizationsOrganizationChangeEventsDetailsEditController 
         }
       }
 
-      if (changeEvent.hasDirtyAttributes) {
-        yield changeEvent.save();
-      }
+      // Note: always save change event as adding a decision is not detected by
+      // the `hasDirtyAttributes` method, which results in the new decision to
+      // be discarded on save.
+      yield changeEvent.save();
 
       this.router.transitionTo(
         'organizations.organization.change-events.details',

--- a/app/controllers/organizations/organization/change-events/details/edit.js
+++ b/app/controllers/organizations/organization/change-events/details/edit.js
@@ -40,7 +40,15 @@ export default class OrganizationsOrganizationChangeEventsDetailsEditController 
           if (decision.isNew) {
             changeEvent.decision = decision;
           }
+
           yield decision.save();
+        }
+
+        if (decision.isEmpty) {
+          changeEvent.decision = null;
+          yield decision.destroyRecord();
+          // Prevents errors in call to `reset()` on transition
+          this.model.decision = null;
         }
       }
 

--- a/app/models/decision.js
+++ b/app/models/decision.js
@@ -14,7 +14,8 @@ export default class DecisionModel extends AbstractValidationModel {
   hasDecisionActivity;
 
   get isEmpty() {
-    return !this.publicationDate && !this.documentLink;
+    // TODO: should this not also check for an activity?
+    return !(this.publicationDate || this.documentLink);
   }
 
   get validationSchema() {


### PR DESCRIPTION
Related to OP-3001

## Context
The underlying problem for the reported bug was that removing the document link resulted in an empty decision. This empty decision was ignored when saving the edited change event, as a result the user's edits were forgotten and the old decision was kept as is.

In the course of investigating this ticket a related problem was encountered. When a user added decision information (document link and/or decision date) to a change event that did not had a decision yet, these edits were also ignored. The underlying cause was that adding a new decision is not detected by `hasDirtyAttributes`. Consequently, the change event, with its newly set decision, was not saved (unless another attribute was changed as well).

## Proposed solution
To correctly deal with **removed** decisions, when the decision is empty on save:
- explicitly remove relation from the change event to the decision; and
- destroy the decision record to avoid obsolete data in the triplestore.

To correctly deal with **new** decisions the guard around `changeEvent.save()` was removed to ensure the change event is always saved.

## Notes
In the process of investigating/solving these bugs I ran into some apparent inconsistencies, a follow-up ticket(s) will be made to look into this. In summary:
- For some types of organizations (AGB, APB, IGS, Police zone, and Assistance zone), the forms only show the document link field and not the decision date field.
- The decision activity is not considered in whether a decision is empty, this might lead to decisions being removed while they still have a valid decision activity.