### PR TITLE
feature: use KBO organization's name as first fallback

### DIFF
--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -178,9 +178,8 @@ export default class OrganizationModel extends AgentModel {
     });
   }
 
-  // TODO: use registered KBO name as fallback
   get abbName() {
-    return this.legalName ?? this.name;
+    return this.legalName ?? this.kboOrganization?.get('name') ?? this.name;
   }
 
   setAbbName(name) {

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -81,4 +81,62 @@ module('Unit | Model | organization', function (hooks) {
       });
     });
   });
+
+  module('abbName', function () {
+    test('it should return the legal name when set', async function (assert) {
+      const model = this.store().createRecord('organization', {
+        legalName: 'some legal name',
+      });
+
+      assert.deepEqual(model.abbName, 'some legal name');
+    });
+
+    test('it should return the name when no legal name is set and there is no KBO organization', async function (assert) {
+      const model = this.store().createRecord('organization', {
+        name: 'some organization name',
+      });
+
+      assert.deepEqual(model.abbName, 'some organization name');
+    });
+
+    test('it should return the KBO organization name when no legal name is set', async function (assert) {
+      const kboOrganizationModel = this.store().createRecord(
+        'kboOrganization',
+        {
+          name: 'kbo organization',
+        }
+      );
+      const model = this.store().createRecord('organization', {
+        kboOrganization: kboOrganizationModel,
+      });
+
+      assert.deepEqual(model.abbName, 'kbo organization');
+    });
+
+    test('it should return the name when no legal name is set and KBO organization has no name', async function (assert) {
+      const kboOrganizationModel = this.store().createRecord('kboOrganization');
+      const model = this.store().createRecord('organization', {
+        kboOrganization: kboOrganizationModel,
+        name: 'some name',
+      });
+
+      assert.deepEqual(model.abbName, 'some name');
+    });
+
+    test('it should return the legal name even if a KBO organization and name are set', async function (assert) {
+      const kboOrganizationModel = this.store().createRecord(
+        'kboOrganization',
+        {
+          name: 'kbo organization',
+        }
+      );
+      const model = this.store().createRecord('organization', {
+        legalName: 'some legal name',
+        name: 'some name',
+        kboOrganization: kboOrganizationModel,
+      });
+
+      assert.deepEqual(model.abbName, 'some legal name');
+    });
+  });
 });


### PR DESCRIPTION
Related to OP-2286

With the introduction of the different organisation names it was intended to use
the KBO organization's name as a fallback value when no legal name is set. But
when this additional name functionality was added the KBO/wegwijs service was
not yet finished and the name variable was used as only fallback.

This resolves the leftover TODO and adds the KBO organization's name as first
fallback value for the `abbName` getter.