### PR TITLE
fix: set properties on correct model

### DIFF
--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -132,8 +132,10 @@
                 <:content>
                   <TrimInput
                     @width="block"
-                    @value={{@model.worshipService.denomination}}
-                    @onUpdate={{fn (mut @model.worshipService.denomination)}}
+                    @value={{this.currentOrganizationModel.denomination}}
+                    @onUpdate={{fn
+                      (mut this.currentOrganizationModel.denomination)
+                    }}
                     id="denomination"
                   />
                 </:content>
@@ -146,26 +148,28 @@
                       <AuControlRadio
                         @label="Ja"
                         @name="is-cross-border"
-                        @value={{@model.worshipService.crossBorder}}
+                        @value={{this.currentOrganizationModel.crossBorder}}
                         @identifier="cross-border-true"
                         @onChange={{fn
-                          (mut @model.worshipService.crossBorder)
+                          (mut this.currentOrganizationModel.crossBorder)
                           true
                         }}
-                        checked={{@model.worshipService.crossBorder}}
+                        checked={{this.currentOrganizationModel.crossBorder}}
                       />
                     </li>
                     <li class="au-c-list-inline__item">
                       <AuControlRadio
                         @label="Nee"
                         @name="is-cross-border"
-                        @value={{@model.worshipService.crossBorder}}
+                        @value={{this.currentOrganizationModel.crossBorder}}
                         @identifier="cross-border-false"
                         @onChange={{fn
-                          (mut @model.worshipService.crossBorder)
+                          (mut this.currentOrganizationModel.crossBorder)
                           false
                         }}
-                        checked={{not @model.worshipService.crossBorder}}
+                        checked={{not
+                          this.currentOrganizationModel.crossBorder
+                        }}
                       />
                     </li>
                   </ul>


### PR DESCRIPTION
The new organisation form contained a bug where the `denomination` and
`crossBorder` properties were not set on the `currentOrganizationModel`
introduced in #611.

Note, these properties are not copied when switching models as they are
exclusive to worship services.