### PR TITLE
fix: correctly include region when editing a PEVA

### DIFF
--- a/app/routes/organizations/organization/core-data/edit.js
+++ b/app/routes/organizations/organization/core-data/edit.js
@@ -88,7 +88,12 @@ export default class OrganizationsOrganizationCoreDataEditRoute extends Route {
 
     let region;
 
-    if (organization.isIgs || organization.isOcmwAssociation) {
+    if (
+      organization.isIgs ||
+      organization.isOcmwAssociation ||
+      organization.isPevaProvince ||
+      organization.isPevaMunicipality
+    ) {
       const primarySite = await organization.primarySite;
       const address = await primarySite.address;
       const municipalityString = address.municipality;

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -189,6 +189,8 @@
                   (or
                     @model.organization.isIgs
                     @model.organization.isOcmwAssociation
+                    @model.organization.isPevaProvince
+                    @model.organization.isPevaMunicipality
                   )
                 }}
                   <Item @labelFor="igs-regio">


### PR DESCRIPTION
Previously the region was not loaded in the model for PEVAs and the field was
not shown in the core data edit form. These changes correct this to align the
behaviour with the new organisation form as well as the core data editing for
other kinds of organizations.