### PR TITLE
Fix/addministrative unit without address and contact

### DIFF
--- a/app/components/site/contact-data-card.hbs
+++ b/app/components/site/contact-data-card.hbs
@@ -8,12 +8,14 @@
   <:card as |Card|>
     <Card.Columns>
       <:left as |Item|>
-        <Item>
-          <:label>Adres</:label>
-          <:content>
-            {{@address.fullAddress}}
-          </:content>
-        </Item>
+        {{#if @address.fullAddress}}
+          <Item>
+            <:label>Adres</:label>
+            <:content>
+              {{@address.fullAddress}}
+            </:content>
+          </Item>
+        {{/if}}
         {{#if @address.province}}
           <Item>
             <:label>Provincie</:label>

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -135,60 +135,67 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
 
     yield Promise.all([
       administrativeUnit.validate({ relaxMandatoryFoundingOrganization: true }),
-      address.validate(),
-      contact.validate(),
-      secondaryContact.validate(),
       identifierKBO.validate(),
       identifierSharepoint.validate(),
     ]);
 
+    if (this.features.isEnabled('edit-contact-data')) {
+      yield Promise.all([
+        address.validate(),
+        contact.validate(),
+        secondaryContact.validate(),
+      ]);
+    }
+
     if (!this.hasValidationErrors) {
-      let primarySite = yield administrativeUnit.primarySite;
+      if (this.features.isEnabled('edit-contact-data')) {
+        let primarySite = yield administrativeUnit.primarySite;
 
-      // TODO : "if" not needed when the data of all administrative units will be correct
-      // they should all have a primary site on creation
-      if (!primarySite) {
-        primarySite = primarySite = this.store.createRecord('site');
-        primarySite.address = address;
-        administrativeUnit.primarySite = primarySite;
-      }
-
-      if (address.hasDirtyAttributes) {
-        if (!address.isCountryBelgium) {
-          address.province = '';
+        // TODO : "if" not needed when the data of all administrative units will be correct
+        // they should all have a primary site on creation
+        if (!primarySite) {
+          primarySite = primarySite = this.store.createRecord('site');
+          primarySite.address = address;
+          administrativeUnit.primarySite = primarySite;
         }
-        address.fullAddress = combineFullAddress(address);
-        address = setEmptyStringsToNull(address);
-        yield address.save();
-      }
 
-      let siteContacts = yield primarySite.contacts;
-
-      if (contact.hasDirtyAttributes) {
-        let isNewContact = contact.isNew;
-
-        contact.telephone = transformPhoneNumbers(contact.telephone);
-        contact = setEmptyStringsToNull(contact);
-        yield contact.save();
-
-        if (isNewContact) {
-          siteContacts.push(contact);
-          yield primarySite.save();
+        if (address.hasDirtyAttributes) {
+          if (!address.isCountryBelgium) {
+            address.province = '';
+          }
+          address.fullAddress = combineFullAddress(address);
+          address = setEmptyStringsToNull(address);
+          yield address.save();
         }
-      }
 
-      if (secondaryContact.hasDirtyAttributes) {
-        let isNewContact = secondaryContact.isNew;
+        let siteContacts = yield primarySite.contacts;
 
-        secondaryContact.telephone = transformPhoneNumbers(
-          secondaryContact.telephone
-        );
-        secondaryContact = setEmptyStringsToNull(secondaryContact);
-        yield secondaryContact.save();
+        if (contact.hasDirtyAttributes) {
+          let isNewContact = contact.isNew;
 
-        if (isNewContact) {
-          siteContacts.push(secondaryContact);
-          yield primarySite.save();
+          contact.telephone = transformPhoneNumbers(contact.telephone);
+          contact = setEmptyStringsToNull(contact);
+          yield contact.save();
+
+          if (isNewContact) {
+            siteContacts.push(contact);
+            yield primarySite.save();
+          }
+        }
+
+        if (secondaryContact.hasDirtyAttributes) {
+          let isNewContact = secondaryContact.isNew;
+
+          secondaryContact.telephone = transformPhoneNumbers(
+            secondaryContact.telephone
+          );
+          secondaryContact = setEmptyStringsToNull(secondaryContact);
+          yield secondaryContact.save();
+
+          if (isNewContact) {
+            siteContacts.push(secondaryContact);
+            yield primarySite.save();
+          }
         }
       }
 

--- a/app/controllers/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/controllers/administrative-units/administrative-unit/core-data/edit.js
@@ -154,7 +154,7 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditController
         // TODO : "if" not needed when the data of all administrative units will be correct
         // they should all have a primary site on creation
         if (!primarySite) {
-          primarySite = primarySite = this.store.createRecord('site');
+          primarySite = this.store.createRecord('site');
           primarySite.address = address;
           administrativeUnit.primarySite = primarySite;
         }

--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -158,7 +158,6 @@ export default class AdministrativeUnitsNewController extends Controller {
     }
 
     if (!this.hasValidationErrors) {
-      const siteTypes = yield this.store.findAll('site-type');
       let newAdministrativeUnit;
       // Set the proper type to the new admin unit
       if (administrativeUnit.isCentralWorshipService) {
@@ -211,6 +210,7 @@ export default class AdministrativeUnitsNewController extends Controller {
           administrativeUnit.isPevaMunicipality ||
           administrativeUnit.isPevaProvince
         ) {
+          const siteTypes = yield this.store.findAll('site-type');
           primarySite.siteType = siteTypes.find(
             (t) => t.id === 'f1381723dec42c0b6ba6492e41d6f5dd'
           );

--- a/app/controllers/administrative-units/new.js
+++ b/app/controllers/administrative-units/new.js
@@ -14,6 +14,7 @@ import { transformPhoneNumbers } from '../../utils/transform-phone-numbers';
 export default class AdministrativeUnitsNewController extends Controller {
   @service router;
   @service store;
+  @service features;
 
   get hasValidationErrors() {
     return (
@@ -144,12 +145,17 @@ export default class AdministrativeUnitsNewController extends Controller {
 
     yield Promise.all([
       administrativeUnit.validate(),
-      address.validate(),
-      contact.validate(),
-      secondaryContact.validate(),
       identifierKBO.validate(),
       identifierSharepoint.validate(),
     ]);
+
+    if (this.features.isEnabled('edit-contact-data')) {
+      yield Promise.all([
+        address.validate(),
+        contact.validate(),
+        secondaryContact.validate(),
+      ]);
+    }
 
     if (!this.hasValidationErrors) {
       const siteTypes = yield this.store.findAll('site-type');
@@ -174,47 +180,49 @@ export default class AdministrativeUnitsNewController extends Controller {
       yield structuredIdentifierSharepoint.save();
       yield identifierSharepoint.save();
 
-      contact = setEmptyStringsToNull(contact);
-      contact.telephone = transformPhoneNumbers(contact.telephone);
-      yield contact.save();
+      if (this.features.isEnabled('edit-contact-data')) {
+        contact = setEmptyStringsToNull(contact);
+        contact.telephone = transformPhoneNumbers(contact.telephone);
+        yield contact.save();
 
-      secondaryContact = setEmptyStringsToNull(secondaryContact);
-      secondaryContact.telephone = transformPhoneNumbers(
-        secondaryContact.telephone
-      );
-      yield secondaryContact.save();
-
-      if (!address.isCountryBelgium) {
-        address.province = '';
-      }
-
-      address.fullAddress = combineFullAddress(address);
-      address = setEmptyStringsToNull(address);
-      yield address.save();
-
-      primarySite.address = address;
-      (yield primarySite.contacts).push(contact, secondaryContact);
-      if (
-        administrativeUnit.isAgb ||
-        administrativeUnit.isApb ||
-        administrativeUnit.isIGS ||
-        administrativeUnit.isPoliceZone ||
-        administrativeUnit.isAssistanceZone ||
-        administrativeUnit.isOcmwAssociation ||
-        administrativeUnit.isPevaMunicipality ||
-        administrativeUnit.isPevaProvince
-      ) {
-        primarySite.siteType = siteTypes.find(
-          (t) => t.id === 'f1381723dec42c0b6ba6492e41d6f5dd'
+        secondaryContact = setEmptyStringsToNull(secondaryContact);
+        secondaryContact.telephone = transformPhoneNumbers(
+          secondaryContact.telephone
         );
+        yield secondaryContact.save();
+
+        if (!address.isCountryBelgium) {
+          address.province = '';
+        }
+
+        address.fullAddress = combineFullAddress(address);
+        address = setEmptyStringsToNull(address);
+        yield address.save();
+
+        primarySite.address = address;
+        (yield primarySite.contacts).push(contact, secondaryContact);
+        if (
+          administrativeUnit.isAgb ||
+          administrativeUnit.isApb ||
+          administrativeUnit.isIGS ||
+          administrativeUnit.isPoliceZone ||
+          administrativeUnit.isAssistanceZone ||
+          administrativeUnit.isOcmwAssociation ||
+          administrativeUnit.isPevaMunicipality ||
+          administrativeUnit.isPevaProvince
+        ) {
+          primarySite.siteType = siteTypes.find(
+            (t) => t.id === 'f1381723dec42c0b6ba6492e41d6f5dd'
+          );
+        }
+        yield primarySite.save();
+        newAdministrativeUnit.primarySite = primarySite;
       }
-      yield primarySite.save();
 
       (yield newAdministrativeUnit.identifiers).push(
         identifierKBO,
         identifierSharepoint
       );
-      newAdministrativeUnit.primarySite = primarySite;
 
       newAdministrativeUnit = setEmptyStringsToNull(newAdministrativeUnit);
 

--- a/app/routes/administrative-units/administrative-unit/core-data/edit.js
+++ b/app/routes/administrative-units/administrative-unit/core-data/edit.js
@@ -46,8 +46,8 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute exte
     let address;
     let contacts;
     if (primarySite) {
-      address = await primarySite.address;
-      contacts = await primarySite.contacts;
+      address = await primarySite?.address;
+      contacts = await primarySite?.contacts;
     } else {
       address = createAddress(this.store);
       contacts = A();
@@ -91,21 +91,22 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataEditRoute exte
     let region;
 
     if (administrativeUnit.isIgs || administrativeUnit.isOcmwAssociation) {
-      const primarySite = await administrativeUnit.primarySite;
-      const address = await primarySite.address;
-      const municipalityString = address.municipality;
-      const municipalityUnit = (
-        await this.store.query('administrative-unit', {
-          filter: {
-            ':exact:name': municipalityString,
-            classification: {
-              ':id:': CLASSIFICATION_CODE.MUNICIPALITY,
+      const address = await primarySite?.address;
+      const municipalityString = address?.municipality;
+      if (municipalityString) {
+        const municipalityUnit = (
+          await this.store.query('administrative-unit', {
+            filter: {
+              ':exact:name': municipalityString,
+              classification: {
+                ':id:': CLASSIFICATION_CODE.MUNICIPALITY,
+              },
             },
-          },
-        })
-      ).at(0);
-      const scope = await municipalityUnit.scope;
-      region = await scope.locatedWithin;
+          })
+        ).at(0);
+        const scope = await municipalityUnit.scope;
+        region = await scope.locatedWithin;
+      }
     }
 
     return {

--- a/app/routes/administrative-units/administrative-unit/core-data/index.js
+++ b/app/routes/administrative-units/administrative-unit/core-data/index.js
@@ -64,21 +64,22 @@ export default class AdministrativeUnitsAdministrativeUnitCoreDataIndexRoute ext
       administrativeUnit.isPevaProvince ||
       administrativeUnit.isPevaMunicipality
     ) {
-      const primarySite = await administrativeUnit.primarySite;
-      const address = await primarySite.address;
-      const municipalityString = address.municipality;
-      const municipalityUnit = (
-        await this.store.query('administrative-unit', {
-          filter: {
-            ':exact:name': municipalityString,
-            classification: {
-              ':id:': CLASSIFICATION_CODE.MUNICIPALITY,
+      const address = await primarySite?.address;
+      const municipalityString = address?.municipality;
+      if (municipalityString) {
+        const municipalityUnit = (
+          await this.store.query('administrative-unit', {
+            filter: {
+              ':exact:name': municipalityString,
+              classification: {
+                ':id:': CLASSIFICATION_CODE.MUNICIPALITY,
+              },
             },
-          },
-        })
-      ).at(0);
-      const scope = await municipalityUnit.scope;
-      region = await scope.locatedWithin;
+          })
+        ).at(0);
+        const scope = await municipalityUnit.scope;
+        region = await scope.locatedWithin;
+      }
     }
 
     const kboOrganization = await administrativeUnit.kboOrganization;

--- a/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/edit.hbs
@@ -346,7 +346,9 @@
               Primaire contactgegevens 
             </:title>
             <:infotext>
-               De primaire contactgegevens kunnen niet langer in het OP aangepast worden. De organisaties kunnen deze gegevens zelf aanpassen via de Contactapp.
+              De primaire contactgegevens kunnen niet langer in het OP aangepast
+              worden. De organisaties kunnen deze gegevens zelf aanpassen via de
+              Contactapp.
             </:infotext>
           </Site::ContactDataCard>
         {{/if}}

--- a/app/templates/administrative-units/administrative-unit/core-data/index.hbs
+++ b/app/templates/administrative-units/administrative-unit/core-data/index.hbs
@@ -144,11 +144,14 @@
                 </Item>
               {{/if}}
               {{#if
-                (or
-                  this.isIGS
-                  this.isOcmwAssociation
-                  @model.administrativeUnit.isPevaMunicipality
-                  @model.administrativeUnit.isPevaProvince
+                (and
+                  (or
+                    this.isIGS
+                    this.isOcmwAssociation
+                    @model.administrativeUnit.isPevaMunicipality
+                    @model.administrativeUnit.isPevaProvince
+                  )
+                  @model.region.label
                 )
               }}
                 <Item>

--- a/app/templates/administrative-units/new.hbs
+++ b/app/templates/administrative-units/new.hbs
@@ -174,7 +174,12 @@
                 </:content>
               </Item>
             {{/if}}
-            {{#if @model.administrativeUnit.isMunicipality}}
+            {{#if
+              (and
+                @model.administrativeUnit.isMunicipality
+                @model.administrativeUnit.scope.locatedWithin
+              )
+            }}
               <Item @labelFor="regio">
                 <:label>Regio</:label>
                 <:content>


### PR DESCRIPTION
Related to OP-3251, Follow-up of https://github.com/lblod/frontend-organization-portal/pull/621

- Remove contact and address validations in new/edit administrative-unit form when edit flag is off
- Handle administrative-unit without address and contact