### PR TITLE
fix: redirect for all organizations

### DIFF
--- a/app/services/deep-link.js
+++ b/app/services/deep-link.js
@@ -4,10 +4,7 @@ import Service, { inject as service } from '@ember/service';
 // TODO: find a better way to store / configure the handlers map
 const REDIRECT_HANDLER = {
   'http://www.w3.org/ns/person#Person': 'person',
-  'http://data.lblod.info/vocabularies/erediensten/BestuurVanDeEredienst':
-    'organization',
-  'http://data.lblod.info/vocabularies/erediensten/CentraalBestuurVanDeEredienst':
-    'organization',
+  'http://www.w3.org/ns/org#Organization': 'organization',
 };
 
 export default class DeepLinkService extends Service {


### PR DESCRIPTION
Related to OP-3279 and KAL-7826

The deep-link service was only configured to handle (central) worship services
and persons. This extends that to all types of organizations.

Examples that can be used for testing, not that you have to be logged with the
appropriate role:
- localhost:4200/redirect?resource=http://data.lblod.info/id/besturenVanDeEredienst/62B9BBA5D7779543F7779555
- localhost:4200/redirect?resource=http://data.lblod.info/id/bestuurseenheden/ba4d960fe3e01984e15fd0b141028bab8f2b9b240bf1e5ab639ba0d7fe4dc522