### PR TITLE
fix: improve local involvement validations

### DIFF
--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -2,26 +2,16 @@ import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
 import { dropTask } from 'ember-concurrency';
-import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import { INVOLVEMENT_TYPE } from 'frontend-organization-portal/models/involvement-type';
 
 export default class OrganizationsOrganizationLocalInvolvementsEditController extends Controller {
   @service router;
   @service store;
 
-  classificationCodes = [
-    CLASSIFICATION.MUNICIPALITY.id,
-    CLASSIFICATION.PROVINCE.id,
-  ];
-
   get hasValidationErrors() {
     return this.model.involvements
       .slice()
       .some((involvement) => involvement.error);
-  }
-
-  get municipalityCode() {
-    return CLASSIFICATION.MUNICIPALITY.id;
   }
 
   setup() {

--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -22,6 +22,7 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
 
   reset() {
     this.deleteAllUnsavedLocalInvolvements();
+    this.model.involvements.map((involvement) => involvement.reset());
   }
 
   deleteAllUnsavedLocalInvolvements() {

--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -1,7 +1,6 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
-import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import { INVOLVEMENT_TYPE } from 'frontend-organization-portal/models/involvement-type';
@@ -9,8 +8,6 @@ import { INVOLVEMENT_TYPE } from 'frontend-organization-portal/models/involvemen
 export default class OrganizationsOrganizationLocalInvolvementsEditController extends Controller {
   @service router;
   @service store;
-  @tracked showTotalFinancingPercentageError = false;
-  @tracked showMoreThanOneFinancialTypeError = false;
 
   classificationCodes = [
     CLASSIFICATION.MUNICIPALITY.id,
@@ -18,45 +15,13 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
   ];
 
   get hasValidationErrors() {
-    let areSomeLocalInvolvementsInvalid = this.model.involvements
+    return this.model.involvements
       .slice()
       .some((involvement) => involvement.error);
-
-    return (
-      areSomeLocalInvolvementsInvalid ||
-      !this.isValidTotalFinancingPercentage ||
-      !this.isOneOrLessFinancialLocalInvolvement
-    );
-  }
-
-  get totalFinancingPercentage() {
-    return this.model.involvements.reduce((percentageTotal, involvement) => {
-      let percentage = parseFloat(involvement.percentage);
-
-      let isValidPercentage = !Number.isNaN(percentage);
-
-      if (isValidPercentage) {
-        return percentageTotal + percentage;
-      } else {
-        return percentageTotal;
-      }
-    }, 0);
   }
 
   get municipalityCode() {
     return CLASSIFICATION.MUNICIPALITY.id;
-  }
-
-  get isValidTotalFinancingPercentage() {
-    let hasFinancialLocalInvolvements = this.model.involvements
-      .slice()
-      .some((involvement) => involvement.isSupervisory);
-
-    if (hasFinancialLocalInvolvements) {
-      return this.totalFinancingPercentage === 100;
-    } else {
-      return true;
-    }
   }
 
   setup() {
@@ -67,22 +32,12 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
 
   reset() {
     this.deleteAllUnsavedLocalInvolvements();
-    this.hideTotalFinancingPercentageError();
-    this.hideMoreThanOneFinancialTypeError();
   }
 
   deleteAllUnsavedLocalInvolvements() {
     this.model.involvements
       .filter((involvement) => involvement.isNew)
       .forEach(this.deleteUnsavedLocalInvolvement);
-  }
-
-  hideTotalFinancingPercentageError() {
-    this.showTotalFinancingPercentageError = false;
-  }
-
-  hideMoreThanOneFinancialTypeError() {
-    this.showMoreThanOneFinancialTypeError = false;
   }
 
   @action
@@ -95,25 +50,6 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
     ) {
       involvement.percentage = 0;
     }
-
-    if (this.isOneOrLessFinancialLocalInvolvement) {
-      this.hideMoreThanOneFinancialTypeError();
-    }
-  }
-
-  @action
-  handlePercentageChange(involvement, event) {
-    let newPercentage = event.target.value;
-    involvement.percentage = newPercentage;
-
-    this.hideTotalFinancingPercentageError();
-  }
-
-  get isOneOrLessFinancialLocalInvolvement() {
-    let hasFinancialLocalInvolvements = this.model.involvements.filter(
-      (involvement) => involvement.isSupervisory
-    );
-    return hasFinancialLocalInvolvements.length <= 1;
   }
 
   @action
@@ -144,6 +80,12 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
     }
   }
 
+  @action
+  handlePercentageChange(involvement, event) {
+    let newPercentage = event.target.value;
+    involvement.percentage = newPercentage;
+  }
+
   @dropTask
   *save(event) {
     event.preventDefault();
@@ -155,22 +97,7 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
     );
     yield Promise.all(validationPromises);
 
-    let areSomeLocalInvolvementsInvalid = involvements
-      .slice()
-      .some((involvement) => involvement.error);
-
-    if (!this.isValidTotalFinancingPercentage) {
-      this.showTotalFinancingPercentageError = true;
-    }
-    if (!this.isOneOrLessFinancialLocalInvolvement) {
-      this.showMoreThanOneFinancialTypeError = true;
-    }
-
-    if (
-      !areSomeLocalInvolvementsInvalid &&
-      this.isValidTotalFinancingPercentage &&
-      this.isOneOrLessFinancialLocalInvolvement
-    ) {
+    if (!this.hasValidationErrors) {
       // isDirty was part of ember-changest and is not available in ember-data
       // TODO: After ember update reimplement a way to check for dirty relationships
       // let localInvolvementsWithUnsavedChanges = involvements.filter(

--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -29,10 +29,6 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
     );
   }
 
-  get isWorshipService() {
-    return this.model.organization.isWorshipService;
-  }
-
   get totalFinancingPercentage() {
     return this.model.involvements.reduce((percentageTotal, involvement) => {
       let percentage = parseFloat(involvement.percentage);
@@ -123,7 +119,7 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
   @action
   addNewLocalInvolvement() {
     let involvement;
-    if (this.isWorshipService) {
+    if (this.model.organization.isWorshipService) {
       involvement = this.store.createRecord('local-involvement', {
         organization: this.model.organization,
         percentage: 0,

--- a/app/models/local-involvement.js
+++ b/app/models/local-involvement.js
@@ -69,7 +69,10 @@ export default class LocalInvolvementModel extends AbstractValidationModel {
         return value;
       }),
       percentage: Joi.when('involvementType.id', {
-        is: Joi.exist().valid(INVOLVEMENT_TYPE.SUPERVISORY),
+        is: Joi.exist().valid(
+          INVOLVEMENT_TYPE.SUPERVISORY,
+          INVOLVEMENT_TYPE.MID_FINANCIAL
+        ),
         then: Joi.number().min(1).max(100).required(),
         otherwise: Joi.number().empty('').allow(null),
       }).messages({

--- a/app/models/worship-administrative-unit.js
+++ b/app/models/worship-administrative-unit.js
@@ -8,6 +8,7 @@ import {
   CentralWorshipServiceCodeList,
   WorshipServiceCodeList,
 } from '../constants/Classification';
+import { CLASSIFICATION } from './administrative-unit-classification-code';
 
 export default class WorshipAdministrativeUnitModel extends AdministrativeUnitModel {
   @belongsTo('recognized-worship-type', {
@@ -45,5 +46,9 @@ export default class WorshipAdministrativeUnitModel extends AdministrativeUnitMo
 
   get isWorshipAdministrativeUnit() {
     return this.isWorshipService || this.isCentralWorshipService;
+  }
+
+  get localInvolvementClassifications() {
+    return [CLASSIFICATION.MUNICIPALITY.id, CLASSIFICATION.PROVINCE.id];
   }
 }

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -62,7 +62,10 @@
         </c.header>
         <c.body as |involvement|>
           <td>
-            {{#let involvement.error.organization.message as |errorMessage|}}
+            {{#let
+              involvement.error.administrativeUnit.message
+              as |errorMessage|
+            }}
               <OrganizationSelect
                 @selected={{involvement.administrativeUnit}}
                 @onChange={{fn (mut involvement.administrativeUnit)}}

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -46,7 +46,7 @@
           >Naam</th>
           <th id="classification">Type instelling</th>
           <th id="involvement-type">Type betrokkenheid</th>
-          {{#if this.isWorshipService}}
+          {{#if @model.organization.isWorshipService}}
             <th id="financial-percentage">
               Financieel percentage
               <AuHelpText @skin="tertiary" class="au-u-margin-top-none">
@@ -91,7 +91,7 @@
           <td>
             {{#let involvement.error.involvementType.message as |errorMessage|}}
               <div class={{if errorMessage "ember-power-select--error"}}>
-                {{#if this.isWorshipService}}
+                {{#if @model.organization.isWorshipService}}
                   {{#if
                     (eq
                       this.municipalityCode
@@ -152,7 +152,7 @@
               {{/if}}
             {{/let}}
           </td>
-          {{#if this.isWorshipService}}
+          {{#if @model.organization.isWorshipService}}
             <td>
               {{#let
                 (or
@@ -208,7 +208,7 @@
     </AuDataTable>
   </form>
 
-  {{#if this.isWorshipService}}
+  {{#if @model.organization.isWorshipService}}
     <div class="au-o-box au-o-box--small">
       <AuButton
         @skin="secondary"

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -69,7 +69,7 @@
                 @allowClear={{involvement.isNew}}
                 @ariaLabelledBy="organization"
                 @error={{errorMessage}}
-                @classificationCodes={{this.classificationCodes}}
+                @classificationCodes={{involvement.worshipAdministrativeUnit.localInvolvementClassifications}}
                 as |organization|
               >
                 {{organization.abbName}}
@@ -89,17 +89,10 @@
             />
           </td>
           <td>
-            {{! TODO: display error messages concerning supervisory on all
-              involvement type fields }}
             {{#let involvement.error.involvementType.message as |errorMessage|}}
               <div class={{if errorMessage "ember-power-select--error"}}>
                 {{#if @model.organization.isWorshipService}}
-                  {{#if
-                    (eq
-                      this.municipalityCode
-                      involvement.administrativeUnit.classification.id
-                    )
-                  }}
+                  {{#if involvement.administrativeUnit.isMunicipality}}
                     <PowerSelect
                       @noMatchesMessage="Geen resultaten"
                       @options={{this.model.involvementTypes}}

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -89,6 +89,8 @@
             />
           </td>
           <td>
+            {{! TODO: display error messages concerning supervisory on all
+              involvement type fields }}
             {{#let involvement.error.involvementType.message as |errorMessage|}}
               <div class={{if errorMessage "ember-power-select--error"}}>
                 {{#if @model.organization.isWorshipService}}
@@ -113,7 +115,6 @@
                       {{involvementType.label}}
                     </PowerSelect>
                   {{else}}
-
                     <PowerSelect
                       @noMatchesMessage="Geen resultaten"
                       @options={{this.model.involvementTypesProvince}}
@@ -145,19 +146,7 @@
           </td>
           {{#if @model.organization.isWorshipService}}
             <td>
-              {{#let
-                (or
-                  involvement.error.percentage.message
-                  (if
-                    (and
-                      involvement.isSupervisory
-                      this.showTotalFinancingPercentageError
-                    )
-                    "Het totaal van alle percentages moet gelijk zijn aan 100"
-                  )
-                )
-                as |errorMessage|
-              }}
+              {{#let involvement.error.percentage.message as |errorMessage|}}
                 <AuInput
                   @disabled={{this.isDisabledPercentage involvement}}
                   @error={{errorMessage}}

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -95,37 +95,24 @@
             {{#let involvement.error.involvementType.message as |errorMessage|}}
               <div class={{if errorMessage "ember-power-select--error"}}>
                 {{#if @model.organization.isWorshipService}}
-                  {{#if involvement.administrativeUnit.isMunicipality}}
-                    <PowerSelect
-                      @noMatchesMessage="Geen resultaten"
-                      @options={{this.model.involvementTypes}}
-                      @selected={{involvement.involvementType}}
-                      @onChange={{fn
-                        this.handleInvolvementTypeSelection
-                        involvement
-                      }}
-                      @ariaLabelledBy="involvement-type"
-                      @allowClear={{involvement.isNew}}
-                      as |involvementType|
-                    >
-                      {{involvementType.label}}
-                    </PowerSelect>
-                  {{else}}
-                    <PowerSelect
-                      @noMatchesMessage="Geen resultaten"
-                      @options={{this.model.involvementTypesProvince}}
-                      @selected={{involvement.involvementType}}
-                      @onChange={{fn
-                        this.handleInvolvementTypeSelection
-                        involvement
-                      }}
-                      @ariaLabelledBy="involvement-type"
-                      @allowClear={{involvement.isNew}}
-                      as |involvementType|
-                    >
-                      {{involvementType.label}}
-                    </PowerSelect>
-                  {{/if}}
+                  <PowerSelect
+                    @noMatchesMessage="Geen resultaten"
+                    @options={{if
+                      involvement.administrativeUnit.isProvince
+                      this.model.involvementTypesProvince
+                      this.model.involvementTypes
+                    }}
+                    @selected={{involvement.involvementType}}
+                    @onChange={{fn
+                      this.handleInvolvementTypeSelection
+                      involvement
+                    }}
+                    @ariaLabelledBy="involvement-type"
+                    @allowClear={{involvement.isNew}}
+                    as |involvementType|
+                  >
+                    {{involvementType.label}}
+                  </PowerSelect>
                 {{else}}
                   <AuInput
                     @width="block"

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -141,15 +141,6 @@
               {{#if errorMessage}}
                 <AuHelpText @error={{true}}>{{errorMessage}}</AuHelpText>
               {{/if}}
-              {{#if
-                (and
-                  involvement.isSupervisory
-                  this.showMoreThanOneFinancialTypeError
-                )
-              }}
-                <AuHelpText @error={{true}}>Er kan slechts één gemeente- of
-                  provincieoverheid optreden als hoofdtoezichthouder</AuHelpText>
-              {{/if}}
             {{/let}}
           </td>
           {{#if @model.organization.isWorshipService}}

--- a/tests/unit/models/local-involvement-test.js
+++ b/tests/unit/models/local-involvement-test.js
@@ -2,6 +2,7 @@ import { module, test } from 'qunit';
 import { setupTest } from 'ember-qunit';
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import { INVOLVEMENT_TYPE } from 'frontend-organization-portal/models/involvement-type';
+import sinon from 'sinon';
 
 module('Unit | Model | local involvement', function (hooks) {
   setupTest(hooks);
@@ -85,6 +86,330 @@ module('Unit | Model | local involvement', function (hooks) {
             message: errorMessage,
           },
         });
+      });
+    });
+
+    module('existsOtherSupervisoryLocalInvolvement', function () {
+      test('it returns true when there is another SUPERVISORY local involvement', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const involvementType = this.store().createRecord('involvement-type', {
+          id: INVOLVEMENT_TYPE.SUPERVISORY,
+        });
+
+        const percentage = '50';
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType,
+          percentage,
+        });
+
+        const otherModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.ok(result);
+      });
+
+      test('it returns false when there is no other local involvement', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const involvementType = this.store().createRecord('involvement-type', {
+          id: INVOLVEMENT_TYPE.SUPERVISORY,
+        });
+
+        const percentage = '50';
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.notOk(result);
+      });
+
+      test('it returns false when there is only another ADVISORY local involvement', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const supervisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.SUPERVISORY,
+          }
+        );
+        const advisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.ADVISORY,
+          }
+        );
+
+        const percentage = '50';
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: supervisoryInvolvementType,
+          percentage,
+        });
+
+        const otherModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: advisoryInvolvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.notOk(result);
+      });
+
+      test('it returns false when there is only another MID_FINANCIAL local involvement', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const supervisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.SUPERVISORY,
+          }
+        );
+        const midFinancialInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+          }
+        );
+
+        const percentage = '50';
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: supervisoryInvolvementType,
+          percentage,
+        });
+
+        const otherModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: midFinancialInvolvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.notOk(result);
+      });
+
+      test('it returns false when there are other non-supervisory local involvements', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const supervisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.SUPERVISORY,
+          }
+        );
+        const advisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.ADVISORY,
+          }
+        );
+        const midFinancialInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+          }
+        );
+        const percentage = '50';
+
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: supervisoryInvolvementType,
+          percentage,
+        });
+
+        const midFinancialModel = this.store().createRecord(
+          'local-involvement',
+          {
+            administrativeUnit,
+            involvementType: midFinancialInvolvementType,
+            percentage,
+          }
+        );
+
+        const advisoryModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: advisoryInvolvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([
+          midFinancialModel,
+          advisoryModel,
+        ]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.notOk(result);
+      });
+
+      test('it returns true when there is at least one other SUPERVISORY local involvement', async function (assert) {
+        const administrativeUnit = this.store().createRecord(
+          'administrative-unit'
+        );
+        const supervisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.SUPERVISORY,
+          }
+        );
+        const advisoryInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.ADVISORY,
+          }
+        );
+        const midFinancialInvolvementType = this.store().createRecord(
+          'involvement-type',
+          {
+            id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+          }
+        );
+        const percentage = '50';
+
+        const model = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: supervisoryInvolvementType,
+          percentage,
+        });
+
+        const otherModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: supervisoryInvolvementType,
+          percentage,
+        });
+
+        const midFinancialModel = this.store().createRecord(
+          'local-involvement',
+          {
+            administrativeUnit,
+            involvementType: midFinancialInvolvementType,
+            percentage,
+          }
+        );
+
+        const advisoryModel = this.store().createRecord('local-involvement', {
+          administrativeUnit,
+          involvementType: advisoryInvolvementType,
+          percentage,
+        });
+
+        const getOtherLocalInvolvementsStub = sinon.stub(
+          model,
+          'getOtherLocalInvolvements'
+        );
+        getOtherLocalInvolvementsStub.resolves([
+          midFinancialModel,
+          advisoryModel,
+          otherModel,
+        ]);
+
+        const result = await model.existsOtherSupervisoryLocalInvolvement();
+        assert.ok(result);
+      });
+    });
+
+    test('it returns an error when there is already a SUPERVISORY local involvement', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.SUPERVISORY,
+      });
+
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: '100',
+      });
+
+      const hasSupervisoryLocalInvolvementStub = sinon.stub(
+        model,
+        'hasSupervisoryLocalInvolvement'
+      );
+      hasSupervisoryLocalInvolvementStub.resolves(true);
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 1);
+      assert.propContains(model.error, {
+        involvementType: {
+          message:
+            'Er kan slechts één gemeente- of provincieoverheid optreden als hoofdtoezichthouder',
+        },
+      });
+    });
+
+    test('it returns an error when there is no SUPERVISORY local involvement', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.ADVISORY,
+      });
+
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: '100',
+      });
+
+      const hasSupervisoryLocalInvolvementStub = sinon.stub(
+        model,
+        'hasSupervisoryLocalInvolvement'
+      );
+      hasSupervisoryLocalInvolvementStub.resolves(false);
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 1);
+      assert.propContains(model.error, {
+        involvementType: {
+          message: 'U dient een toezichthoudende overheid aan te duiden',
+        },
       });
     });
   });


### PR DESCRIPTION
OP-3185 and OP-2993

Primary changes:
- Validate financing percentage for mid financing (*nl. mede-financierend*)
  local involvements.
- Move the validation whether there is a supervisory (*nl. toezichtoudend*)
  local involvement to the model and enforce there always is a supervisory local
  involvement.
- Move total percentage validation into the model and take mid financing local
  involvements into consideration.