### PR TITLE
[OP-3327] Use "Organisatie" as the title in the "KBO gegevens" tab

### DIFF
--- a/app/components/kbo-organization/data-card.hbs
+++ b/app/components/kbo-organization/data-card.hbs
@@ -1,6 +1,6 @@
 {{#if @kboOrganization}}
   <DataCard>
-    <:title>Bestuurseenheid</:title>
+    <:title>Organisatie</:title>
     <:card as |Card|>
       <Card.Columns>
         <:left as |Item|>


### PR DESCRIPTION
This makes it consistent with the "ABB gegevens" tab