### PR TITLE
[OP-3325] Add whitespace between each alternative name item

### DIFF
--- a/app/helpers/join-array.js
+++ b/app/helpers/join-array.js
@@ -1,0 +1,3 @@
+export default function joinArray(array = [], separator = ', ') {
+  return array.join(separator);
+}

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -82,7 +82,7 @@
                 <Item>
                   <:label>Alternatieve naam</:label>
                   <:content>
-                    {{@model.organization.alternativeName}}
+                    {{join-array @model.organization.alternativeName}}
                   </:content>
                 </Item>
               {{/if}}

--- a/tests/integration/helpers/join-array-test.js
+++ b/tests/integration/helpers/join-array-test.js
@@ -1,0 +1,20 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'frontend-organization-portal/tests/helpers';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | join-array', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it converts an array to a string using the .join method', async function (assert) {
+    await render(hbs`{{join-array (array "foo" "bar")}}`);
+    assert
+      .dom(this.element)
+      .hasText('foo, bar', 'it defaults to ", " as the separator');
+  });
+
+  test('it accepts an optional separator', async function (assert) {
+    await render(hbs`{{join-array (array "foo" "bar") " - "}}`);
+    assert.dom(this.element).hasText('foo - bar');
+  });
+});


### PR DESCRIPTION
An organization can have multiple alternative names. We display this list in a template directly, which causes the VM to call `.toString` on it which defaults to joining the array elements without any whitespace.

This adds a new `join-array` helper that can use different separators to join the array.