### PR TITLE
[OP-3343] Appuniversum v3 update

### DIFF
--- a/app/components/app-header.hbs
+++ b/app/components/app-header.hbs
@@ -11,7 +11,7 @@
       @alignment="right"
       role="menu"
     >
-      <AuLink @skin="tertiary" role="menuitem" @route="select-role">
+      <AuLink role="menuitem" @route="select-role">
         <AuIcon @icon="user" @alignment="left" />Wissel van rol
       </AuLink>
 

--- a/app/components/datepicker.hbs
+++ b/app/components/datepicker.hbs
@@ -3,7 +3,7 @@
   @error={{@error}}
   {{on 'focusout' this.focusOut}}
   @width={{this.width}}
-  @id={{@id}}
+  id={{@id}}
   {{au-date-input value=@value onChange=this.onChange}}
   ...attributes
 />

--- a/app/components/related-organizations-view-table.hbs
+++ b/app/components/related-organizations-view-table.hbs
@@ -12,9 +12,11 @@
       {{! TODO: place next to each other }}
       <div class="au-o-box">
         <AuToggleSwitch
-          @label="Verberg niet actieve organisaties"
           @checked={{@organizationStatus}}
-        />
+          @onChange={{fn @onOrganizationStatusChange (not @organizationStatus)}}
+        >
+          Verberg niet actieve organisaties
+        </AuToggleSwitch>
 
         <MembershipRoleSelect
           @options={{@model.roles}}

--- a/app/components/trim-input.hbs
+++ b/app/components/trim-input.hbs
@@ -3,8 +3,8 @@
   @error={{@error}}
   autocomplete={{@autocomplete}}
   @width={{@width}}
-  @id={{@id}}
-  @value={{@value}}
+  id={{@id}}
+  value={{@value}}
   {{on "focusout" (perform this.trimInput)}}
   ...attributes
 />

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -133,8 +133,9 @@ export default class OrganizationsNewController extends Controller {
   }
 
   @action
-  setKbo(value) {
-    this.model.structuredIdentifierKBO.localId = value;
+  setKbo(event) {
+    this.model.structuredIdentifierKBO.localId =
+      event.target.inputmask.unmaskedvalue();
   }
 
   @action

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -34,8 +34,9 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
   }
 
   @action
-  setKbo(value) {
-    this.model.structuredIdentifierKBO.localId = value;
+  setKbo(event) {
+    this.model.structuredIdentifierKBO.localId =
+      event.target.inputmask.unmaskedvalue();
   }
 
   @dropTask

--- a/app/helpers/boolean.js
+++ b/app/helpers/boolean.js
@@ -1,0 +1,3 @@
+export default function boolean(value) {
+  return Boolean(value);
+}

--- a/app/helpers/event-value.js
+++ b/app/helpers/event-value.js
@@ -1,0 +1,5 @@
+export default function eventValue(handler) {
+  return function (event) {
+    return handler(event.target.value);
+  };
+}

--- a/app/styles/app.scss
+++ b/app/styles/app.scss
@@ -1,115 +1,30 @@
-/* ==================================
-   #APPUNIVERSUM
-   ================================== */
+// SETTINGS: Project settings and variables
+@import '@appuniversum/ember-appuniversum/styles/a-settings';
 
-/**
- * A design universe for Flanders GOV applications
- */
+// TOOLS: Mixins
+@import '@appuniversum/ember-appuniversum/styles/a-tools';
 
-/**
- * CONTENTS
- * ---
- * SETTINGS: Project settings and variables
- * TOOLS: Mixins
- * GENERIC: Reset, global box-sizing and font-styles
- * ELEMENTS: Plain html tag styling
- * OBJECTS: OOCSS unstyled objects (namespace: '.au-o-...')
- * COMPONENTS: Components (namespace: '.au-c-...')
- * UTILITIES: Single function helper classes (namespace: '.au-u-...')
- */
+// GENERIC: Reset, global box-sizing and font-styles
+@import '@appuniversum/ember-appuniversum/styles/a-generic';
 
-// VARIABLES
+// ELEMENTS: Plain html tag styling
+@import '@appuniversum/ember-appuniversum/styles/a-elements';
 
-@import 'ember-appuniversum/s-colors';
-@import 'ember-appuniversum/s-global';
-@import 'ember-appuniversum/s-utilities';
-@import 'ember-appuniversum/s-root';
+// OBJECTS: OOCSS unstyled objects (namespace: '.au-o-...')
+@import '@appuniversum/ember-appuniversum/styles/a-objects';
 
-// MIXINS
-@import 'ember-appuniversum/t-font-size';
-@import 'ember-appuniversum/t-sass-mq';
-
-// GENERIC
-@import 'ember-appuniversum/g-reset';
-@import 'ember-appuniversum/g-box-sizing';
-@import 'ember-appuniversum/g-font';
-
-// ELEMENTS
-@import 'ember-appuniversum/e-page';
-
-// OBJECTS
-@import 'ember-appuniversum/o-box';
-@import 'ember-appuniversum/o-flow';
-@import 'ember-appuniversum/o-grid';
-@import 'ember-appuniversum/o-layout';
-@import 'ember-appuniversum/o-region';
-
-// COMPONENTS
-@import 'ember-appuniversum/c-accordion';
-@import 'ember-appuniversum/c-alert';
-@import 'ember-appuniversum/c-app';
-@import 'ember-appuniversum/c-badge';
-@import 'ember-appuniversum/c-body-container';
-@import 'ember-appuniversum/c-brand';
-@import 'ember-appuniversum/c-button';
-@import 'ember-appuniversum/c-button-group';
-@import 'ember-appuniversum/c-card';
-@import 'ember-appuniversum/c-content';
-@import 'ember-appuniversum/c-content-header';
-@import 'ember-appuniversum/c-control';
-@import 'ember-appuniversum/c-data-table';
-@import 'ember-appuniversum/c-dropdown';
-@import 'ember-appuniversum/c-file-upload';
-@import 'ember-appuniversum/c-form';
-@import 'ember-appuniversum/c-heading';
-@import 'ember-appuniversum/c-help-text';
-@import 'ember-appuniversum/c-hr';
-@import 'ember-appuniversum/c-icon';
-@import 'ember-appuniversum/c-input';
-@import 'ember-appuniversum/c-label';
-@import 'ember-appuniversum/c-link';
-@import 'ember-appuniversum/c-list-horizontal';
-@import 'ember-appuniversum/c-list-navigation';
-@import 'ember-appuniversum/c-loader';
-@import 'ember-appuniversum/c-pagination';
-@import 'ember-appuniversum/c-pill';
-@import 'ember-appuniversum/c-main-container';
-@import 'ember-appuniversum/c-main-header';
-@import 'ember-appuniversum/c-main-footer';
-@import 'ember-appuniversum/c-modal';
-@import 'ember-appuniversum/c-sidebar';
-@import 'ember-appuniversum/c-sidebar-action';
-@import 'ember-appuniversum/c-table';
-@import 'ember-appuniversum/c-tabs';
-@import 'ember-appuniversum/c-textarea';
-@import 'ember-appuniversum/c-timepicker';
-@import 'ember-appuniversum/c-toolbar';
-@import 'ember-appuniversum/c-toggle-switch';
+// COMPONENTS: Components (namespace: '.au-c-...')
+@import '@appuniversum/ember-appuniversum/styles/a-components';
 @import 'components/cards';
 @import 'components/sidebar-container';
 @import 'components/table-message';
 @import 'components/c-rich-text-editor';
 
 // PLUGINS
-@import 'ember-appuniversum/p-ember-power-select';
-@import 'ember-appuniversum/p-duet-datepicker';
+@import '@appuniversum/ember-appuniversum/styles/a-plugins';
 
-// UTILITIES
-@import 'ember-appuniversum/u-align-text';
-@import 'ember-appuniversum/u-background';
-@import 'ember-appuniversum/u-break-word';
-@import 'ember-appuniversum/u-flex';
-@import 'ember-appuniversum/u-headings';
-@import 'ember-appuniversum/u-hide';
-@import 'ember-appuniversum/u-font-family';
-@import 'ember-appuniversum/u-font-weights';
-@import 'ember-appuniversum/u-max-widths';
-@import 'ember-appuniversum/u-paragraphs';
-@import 'ember-appuniversum/u-print';
-@import 'ember-appuniversum/u-responsive-spacings';
-@import 'ember-appuniversum/u-spacings';
-@import 'ember-appuniversum/u-visible';
-@import 'ember-appuniversum/u-widths';
+// UTILITIES: Single function helper classes (namespace: '.au-u-...')
+@import '@appuniversum/ember-appuniversum/styles/a-utilities';
 
 // ember-rdfa-editor styles
 // TODO: `@import "ember-rdfa-editor";` imports annotation styles which are _huge_ when compiled

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -4,6 +4,8 @@
   )
 }}
 
+<AuModalContainer />
+
 <AuApp class='{{if this.showEnvironment 'au-c-app--environment'}}'>
   {{#if this.showEnvironment}}
     <EnvironmentBanner
@@ -32,4 +34,4 @@
       {{outlet}}
     </div>
   </main>
-</AuApp> 
+</AuApp>

--- a/app/templates/mock-login.hbs
+++ b/app/templates/mock-login.hbs
@@ -15,7 +15,7 @@
                 class="au-o-box au-o-box--small au-c-card au-u-margin-bottom-small"
               >
                 <AuButton
-                  @skin="tertiary"
+                  @skin="link"
                   {{on
                     "click"
                     (fn login.login account.id account.user.group.id)

--- a/app/templates/organizations/index.hbs
+++ b/app/templates/organizations/index.hbs
@@ -87,7 +87,7 @@
             />
           </div>
           <div class="au-o-grid__item">
-            <AuButton @skin="tertiary" type="reset">
+            <AuButton @skin="link" type="reset">
               <AuIcon @icon="cross" @alignment="left" />
               Herstel alle filters
             </AuButton>

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -225,15 +225,17 @@
               <:label>{{@model.identifierKBO.idName}}</:label>
               <:content as |hasError|>
                 <AuInput
-                  @maskPlaceholder="_"
-                  autocomplete="off"
-                  @mask="####.###.###"
-                  @onChange={{this.setKbo}}
                   @width="block"
-                  @value={{@model.structuredIdentifierKBO.localId}}
                   @error={{hasError}}
+                  autocomplete="off"
+                  value={{@model.structuredIdentifierKBO.localId}}
                   id="kbo-identifier"
+                  class="au-c-input--mask"
                   placeholder="____.___.___"
+                  {{au-inputmask
+                    options=(hash mask="####.###.###" placeholder="_")
+                  }}
+                  {{on "input" this.setKbo}}
                 />
               </:content>
               <:error as |error|>

--- a/app/templates/organizations/new.hbs
+++ b/app/templates/organizations/new.hbs
@@ -143,36 +143,20 @@
               <Item @alignTop={{true}}>
                 <:label>Grensoverschrijvend</:label>
                 <:content>
-                  <ul class="au-c-list-inline">
-                    <li class="au-c-list-inline__item">
-                      <AuControlRadio
-                        @label="Ja"
-                        @name="is-cross-border"
-                        @value={{this.currentOrganizationModel.crossBorder}}
-                        @identifier="cross-border-true"
-                        @onChange={{fn
-                          (mut this.currentOrganizationModel.crossBorder)
-                          true
-                        }}
-                        checked={{this.currentOrganizationModel.crossBorder}}
-                      />
-                    </li>
-                    <li class="au-c-list-inline__item">
-                      <AuControlRadio
-                        @label="Nee"
-                        @name="is-cross-border"
-                        @value={{this.currentOrganizationModel.crossBorder}}
-                        @identifier="cross-border-false"
-                        @onChange={{fn
-                          (mut this.currentOrganizationModel.crossBorder)
-                          false
-                        }}
-                        checked={{not
-                          this.currentOrganizationModel.crossBorder
-                        }}
-                      />
-                    </li>
-                  </ul>
+                  <AuRadioGroup
+                    @alignment="inline"
+                    @name="is-cross-border"
+                    @selected={{boolean
+                      this.currentOrganizationModel.crossBorder
+                    }}
+                    @onChange={{fn
+                      (mut this.currentOrganizationModel.crossBorder)
+                    }}
+                    as |Group|
+                  >
+                    <Group.Radio @value={{true}}>Ja</Group.Radio>
+                    <Group.Radio @value={{false}}>Nee</Group.Radio>
+                  </AuRadioGroup>
                 </:content>
               </Item>
             {{/if}}

--- a/app/templates/organizations/organization/change-events/details/edit.hbs
+++ b/app/templates/organizations/organization/change-events/details/edit.hbs
@@ -53,9 +53,13 @@
               <:label>Beschrijving</:label>
               <:content>
                 <AuTextarea
-                  @value={{@model.changeEvent.description}}
                   @width="block"
+                  value={{@model.changeEvent.description}}
                   id="change-event-description"
+                  {{on
+                    "input"
+                    (event-value (fn (mut @model.changeEvent.description)))
+                  }}
                 />
               </:content>
             </Item>

--- a/app/templates/organizations/organization/change-events/new.hbs
+++ b/app/templates/organizations/organization/change-events/new.hbs
@@ -61,9 +61,13 @@
               <:label>Beschrijving</:label>
               <:content>
                 <AuTextarea
-                  @value={{@model.changeEvent.description}}
                   @width="block"
+                  value={{@model.changeEvent.description}}
                   id="change-event-description"
+                  {{on
+                    "input"
+                    (event-value (fn (mut @model.changeEvent.description)))
+                  }}
                 />
               </:content>
             </Item>

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -146,34 +146,16 @@
                   <Item>
                     <:label>Grensoverschrijvend</:label>
                     <:content>
-                      <ul class="au-c-list-inline">
-                        <li class="au-c-list-inline__item">
-                          <AuControlRadio
-                            @label="Ja"
-                            @name="is-cross-border"
-                            @value={{@model.organization.crossBorder}}
-                            @identifier="cross-border-true"
-                            @onChange={{fn
-                              (mut @model.organization.crossBorder)
-                              true
-                            }}
-                            checked={{@model.organization.crossBorder}}
-                          />
-                        </li>
-                        <li class="au-c-list-inline__item">
-                          <AuControlRadio
-                            @label="Nee"
-                            @name="is-cross-border"
-                            @value={{@model.organization.crossBorder}}
-                            @identifier="cross-border-false"
-                            @onChange={{fn
-                              (mut @model.organization.crossBorder)
-                              false
-                            }}
-                            checked={{not @model.organization.crossBorder}}
-                          />
-                        </li>
-                      </ul>
+                      <AuRadioGroup
+                        @alignment="inline"
+                        @name="is-cross-border"
+                        @selected={{boolean @model.organization.crossBorder}}
+                        @onChange={{fn (mut @model.organization.crossBorder)}}
+                        as |Group|
+                      >
+                        <Group.Radio @value={{true}}>Ja</Group.Radio>
+                        <Group.Radio @value={{false}}>Nee</Group.Radio>
+                      </AuRadioGroup>
                     </:content>
                   </Item>
                 {{/if}}

--- a/app/templates/organizations/organization/core-data/edit.hbs
+++ b/app/templates/organizations/organization/core-data/edit.hbs
@@ -241,15 +241,17 @@
                   <:label>{{@model.identifierKBO.idName}}</:label>
                   <:content as |hasError|>
                     <AuInput
-                      @maskPlaceholder="_"
-                      autocomplete="off"
-                      @mask="####.###.###"
-                      @onChange={{this.setKbo}}
                       @width="block"
-                      @value={{@model.structuredIdentifierKBO.localId}}
                       @error={{hasError}}
+                      autocomplete="off"
+                      value={{@model.structuredIdentifierKBO.localId}}
                       id="kbo-identifier"
+                      class="au-c-input--mask"
                       placeholder="____.___.___"
+                      {{au-inputmask
+                        options=(hash mask="####.###.###" placeholder="_")
+                      }}
+                      {{on "input" this.setKbo}}
                     />
                   </:content>
                   <:error as |error|>

--- a/app/templates/organizations/organization/core-data/index.hbs
+++ b/app/templates/organizations/organization/core-data/index.hbs
@@ -39,7 +39,6 @@
     <AuTabs as |Tab|>
       <Tab class="au-u-1-1">
         <AuLink
-          @skin="naked"
           @width="block"
           class={{if
             this.showAbbData
@@ -52,7 +51,6 @@
 
       <Tab class="au-u-1-1">
         <AuLink
-          @skin="naked"
           @width="block"
           class={{if
             this.showAbbData

--- a/app/templates/organizations/organization/governing-bodies/governing-body/edit.hbs
+++ b/app/templates/organizations/organization/governing-bodies/governing-body/edit.hbs
@@ -43,8 +43,8 @@
                   <:content>
                     <AuInput
                       @width="block"
-                      @value={{@model.governingBodyClassification.label}}
                       @disabled={{true}}
+                      value={{@model.governingBodyClassification.label}}
                     />
                   </:content>
                 </Item>
@@ -53,8 +53,8 @@
                   <:content>
                     <AuInput
                       @width="block"
-                      @value={{@model.governingBody.period}}
                       @disabled={{true}}
+                      value={{@model.governingBody.period}}
                     />
                   </:content>
                 </Item>

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -86,8 +86,8 @@
           <td>
             <AuInput
               @width="block"
-              @value={{involvement.administrativeUnit.classification.label}}
               @disabled={{true}}
+              value={{involvement.administrativeUnit.classification.label}}
               aria-labelledby="classification"
             />
           </td>
@@ -116,8 +116,8 @@
                 {{else}}
                   <AuInput
                     @width="block"
-                    @value={{involvement.involvementType.label}}
                     @disabled={{true}}
+                    value={{involvement.involvementType.label}}
                     aria-labelledby="involvement-type"
                   />
                 {{/if}}
@@ -133,10 +133,10 @@
                 <AuInput
                   @disabled={{this.isDisabledPercentage involvement}}
                   @error={{errorMessage}}
-                  @type="number"
+                  type="number"
                   step="any"
                   aria-labelledby="financial-percentage"
-                  @value={{involvement.percentage}}
+                  value={{involvement.percentage}}
                   {{on "input" (fn this.handlePercentageChange involvement)}}
                 />
                 {{#if errorMessage}}

--- a/app/templates/organizations/organization/related-organizations/index.hbs
+++ b/app/templates/organizations/organization/related-organizations/index.hbs
@@ -54,6 +54,7 @@
         @model={{@model}}
         id="relatedOrganizations"
         @organizationStatus={{this.organizationStatus}}
+        @onOrganizationStatusChange={{fn (mut this.organizationStatus)}}
         @sort={{this.sort}}
         @page={{this.page}}
         @size={{this.size}}

--- a/app/templates/organizations/organization/sites/new.hbs
+++ b/app/templates/organizations/organization/sites/new.hbs
@@ -69,28 +69,16 @@
                 <Item>
                   <:label>Primair correspondentieadres</:label>
                   <:content>
-                    <ul class="au-c-list-inline">
-                      <li class="au-c-list-inline__item">
-                        <AuControlRadio
-                          @label="Ja"
-                          @name="is-primary-site"
-                          @value={{this.isPrimarySite}}
-                          @identifier="site-true"
-                          @onChange={{fn (mut this.isPrimarySite) true}}
-                          checked={{this.isPrimarySite}}
-                        />
-                      </li>
-                      <li class="au-c-list-inline__item">
-                        <AuControlRadio
-                          @label="Nee"
-                          @name="is-primary-site"
-                          @value={{this.isPrimarySite}}
-                          @identifier="site-false"
-                          @onChange={{fn (mut this.isPrimarySite) false}}
-                          checked={{not this.isPrimarySite}}
-                        />
-                      </li>
-                    </ul>
+                    <AuRadioGroup
+                      @alignment="inline"
+                      @name="is-primary-site"
+                      @selected={{this.isPrimarySite}}
+                      @onChange={{fn (mut this.isPrimarySite)}}
+                      as |Group|
+                    >
+                      <Group.Radio @value={{true}}>Ja</Group.Radio>
+                      <Group.Radio @value={{false}}>Nee</Group.Radio>
+                    </AuRadioGroup>
                   </:content>
                 </Item>
               </:right>

--- a/app/templates/organizations/organization/sites/site/edit.hbs
+++ b/app/templates/organizations/organization/sites/site/edit.hbs
@@ -76,28 +76,16 @@
                 <Item @errorMessage={{this.isNoPrimarySiteErrorMessage}}>
                   <:label>Primair correspondentieadres</:label>
                   <:content>
-                    <ul class="au-c-list-inline">
-                      <li class="au-c-list-inline__item">
-                        <AuControlRadio
-                          @label="Ja"
-                          @name="is-primary-site"
-                          @value={{this.isPrimarySite}}
-                          @identifier="primary-site-true"
-                          @onChange={{this.updateIsPrimarySite true}}
-                          checked={{this.isPrimarySite}}
-                        />
-                      </li>
-                      <li class="au-c-list-inline__item">
-                        <AuControlRadio
-                          @label="Nee"
-                          @name="is-primary-site"
-                          @value={{this.isPrimarySite}}
-                          @identifier="primary-site-false"
-                          @onChange={{this.updateIsPrimarySite false}}
-                          checked={{not this.isPrimarySite}}
-                        />
-                      </li>
-                    </ul>
+                    <AuRadioGroup
+                      @alignment="inline"
+                      @name="is-primary-site"
+                      @selected={{this.isPrimarySite}}
+                      @onChange={{this.updateIsPrimarySite}}
+                      as |Group|
+                    >
+                      <Group.Radio @value={{true}}>Ja</Group.Radio>
+                      <Group.Radio @value={{false}}>Nee</Group.Radio>
+                    </AuRadioGroup>
                   </:content>
                 </Item>
               </:right>

--- a/app/templates/people/index.hbs
+++ b/app/templates/people/index.hbs
@@ -78,9 +78,11 @@
           </PageHeader>
           <div class="au-o-box">
             <AuToggleSwitch
-              @label="Verberg niet actieve posities"
               @checked={{this.status}}
-            />
+              @onChange={{fn (mut this.status) (not this.status)}}
+            >
+              Verberg niet actieve posities
+            </AuToggleSwitch>
           </div>
         </menu.general>
       </t.menu>

--- a/app/templates/people/index.hbs
+++ b/app/templates/people/index.hbs
@@ -45,7 +45,7 @@
             />
           </div>
           <div class="au-o-grid__item">
-            <AuButton @skin="tertiary" type="reset">
+            <AuButton @skin="link" type="reset">
               <AuIcon @icon="cross" @alignment="left" />
               Herstel alle filters
             </AuButton>

--- a/app/templates/select-role.hbs
+++ b/app/templates/select-role.hbs
@@ -10,7 +10,7 @@
               class="au-o-box au-o-box--small au-c-card au-u-margin-bottom-small"
             >
               <AuButton
-                @skin="tertiary"
+                @skin="link"
                 {{on "click" (fn this.updateActiveRole role)}}
               >
                 <strong>

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,10 +8,6 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
-    // TODO: remove when updating to Appuniversum v3
-    '@appuniversum/ember-appuniversum': {
-      disableWormholeElement: true,
-    },
     autoprefixer: {
       enabled: true,
       cascade: true,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,10 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
+    // TODO: remove when updating to Appuniversum v3
+    '@appuniversum/ember-appuniversum': {
+      disableWormholeElement: true,
+    },
     autoprefixer: {
       enabled: true,
       cascade: true,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,12 +8,6 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
-    sassOptions: {
-      sourceMapEmbed: true,
-      includePaths: [
-        'node_modules/@appuniversum/ember-appuniversum/app/styles',
-      ],
-    },
     autoprefixer: {
       enabled: true,
       cascade: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.26.0",
       "license": "MIT",
       "devDependencies": {
-        "@appuniversum/ember-appuniversum": "^2.18.0",
+        "@appuniversum/ember-appuniversum": "^3.5.0",
         "@babel/eslint-parser": "^7.21.3",
         "@babel/plugin-proposal-decorators": "^7.21.0",
         "@ember/optional-features": "^2.0.0",
@@ -105,137 +105,468 @@
       }
     },
     "node_modules/@appuniversum/ember-appuniversum": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-2.18.0.tgz",
-      "integrity": "sha512-W67tWC3racq9Eq9ziV4heFhAPeoRG0ILPtjKmYwM0BeIQ8k+L6Fp3Vrnh741yQBERNkdAr6F8XQu4G8mNbkBow==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@appuniversum/ember-appuniversum/-/ember-appuniversum-3.5.0.tgz",
+      "integrity": "sha512-vhDWMLcWvBZmUziXjow/w+vfEW3XTrvhDjS4cQtKjGGHWa6Os6F0e49E8CchgwBCYC9XNCgfqrBWee29dDj1Tg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@babel/core": "^7.22.10",
+        "@babel/core": "^7.23.2",
         "@duetds/date-picker": "^1.4.0",
         "@embroider/macros": "^1.9.0",
         "@floating-ui/dom": "^1.1.0",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
-        "@zestia/ember-auto-focus": "^4.2.0",
         "ember-auto-import": "^2.6.3",
-        "ember-cli-babel": "^7.26.11",
+        "ember-cli-babel": "^8.2.0",
         "ember-cli-htmlbars": "^6.3.0",
-        "ember-concurrency": "2.x || ^3.1.0",
+        "ember-concurrency": "^3.1.0",
         "ember-data-table": "^2.1.0",
-        "ember-file-upload": "^7.0.3",
+        "ember-file-upload": "^8.4.0",
         "ember-focus-trap": "^1.1.0",
-        "ember-modifier": "^3.2.7",
-        "ember-template-imports": "^3.4.2",
+        "ember-modifier": "^4.1.0",
+        "ember-template-imports": "^4.1.1",
         "ember-test-selectors": "^6.0.0",
-        "ember-truth-helpers": "^3.1.1",
-        "inputmask": "^5.0.7",
+        "ember-truth-helpers": "^3.1.1 || ^4.0.3",
+        "inputmask": "^5.0.9-beta.45",
         "merge-anything": "^5.1.3",
         "tracked-toolbox": "^2.0.0"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": ">= 18"
       },
       "optionalDependencies": {
         "ember-power-select": "2.x || 3.x || 4.x || 5.x || 6.x || 7.x"
       },
       "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0 || ^5.0.0"
+        "ember-source": "^4.12.0 || ^5.0.0",
+        "tracked-built-ins": "^3.3.0"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
       "engines": {
-        "node": ">= 12.*"
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/@babel/runtime": {
+      "version": "7.12.18",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.18.tgz",
+      "integrity": "sha512-BogPQ7ciE6SYAUPtlm9tWbgI9+2AgqSam6QivMgXgAT+fKbgppaj4ZX15MHeLC1PVF5sNk70huBu20XxWOs8Cg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
+        "regenerator-runtime": "^0.13.4"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/async-disk-cache": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/async-disk-cache/-/async-disk-cache-2.1.0.tgz",
+      "integrity": "sha512-iH+boep2xivfD9wMaZWkywYIURSmsL96d6MoqrC94BnGSvXE4Quf8hnJiHGFYhw/nLeIa1XyRaf4vvcvkwAefg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
+        "debug": "^4.1.1",
+        "heimdalljs": "^0.2.3",
+        "istextorbinary": "^2.5.1",
+        "mkdirp": "^0.5.0",
+        "rimraf": "^3.0.0",
+        "rsvp": "^4.8.5",
+        "username-sync": "^1.0.2"
       },
       "engines": {
-        "node": ">=10"
+        "node": "8.* || >= 10.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/babel-plugin-module-resolver": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-5.0.2.tgz",
+      "integrity": "sha512-9KtaCazHee2xc0ibfqsDeamwDps6FZNo5S0Q81dUqEuFzVwPhcT4J5jOqIVvgCA3Q/wO9hKYxN/Ds3tIsp5ygg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-babel-config": "^2.1.1",
+        "glob": "^9.3.3",
+        "pkg-up": "^3.1.0",
+        "reselect": "^4.1.7",
+        "resolve": "^1.22.8"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-babel-transpiler": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/broccoli-babel-transpiler/-/broccoli-babel-transpiler-8.0.0.tgz",
+      "integrity": "sha512-3HEp3flvasUKJGWERcrPgM1SWvHJ0O/fmbEtY9L4kDyMSnqjY6hTYvNvgWCIgbwXAYAUlZP0vjAQsmyLNGLwFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-persistent-filter": "^3.0.0",
+        "clone": "^2.1.2",
+        "hash-for-dep": "^1.4.7",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.9",
+        "json-stable-stringify": "^1.0.1",
+        "rsvp": "^4.8.4",
+        "workerpool": "^6.0.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.17.9"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-persistent-filter": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/broccoli-persistent-filter/-/broccoli-persistent-filter-3.1.3.tgz",
+      "integrity": "sha512-Q+8iezprZzL9voaBsDY3rQVl7c7H5h+bvv8SpzCZXPZgfBFCbx7KFQ2c3rZR6lW5k4Kwoqt7jG+rZMUg67Gwxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-disk-cache": "^2.0.0",
+        "async-promise-queue": "^1.0.3",
+        "broccoli-plugin": "^4.0.3",
+        "fs-tree-diff": "^2.0.0",
+        "hash-for-dep": "^1.5.0",
+        "heimdalljs": "^0.2.1",
+        "heimdalljs-logger": "^0.1.7",
+        "promise-map-series": "^0.2.1",
+        "rimraf": "^3.0.0",
+        "symlink-or-copy": "^1.0.1",
+        "sync-disk-cache": "^2.0.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-plugin": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-4.0.7.tgz",
+      "integrity": "sha512-a4zUsWtA1uns1K7p9rExYVYG99rdKeGRymW0qOCNkvDPHQxVi3yVyJHhQbM3EZwdt2E0mnhr5e0c/bPpJ7p3Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-node-api": "^1.7.0",
+        "broccoli-output-wrapper": "^3.2.5",
+        "fs-merger": "^3.2.1",
+        "promise-map-series": "^0.3.0",
+        "quick-temp": "^0.1.8",
+        "rimraf": "^3.0.2",
+        "symlink-or-copy": "^1.3.1"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/broccoli-plugin/node_modules/promise-map-series": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/promise-map-series/-/promise-map-series-0.3.0.tgz",
+      "integrity": "sha512-3npG2NGhTc8BWBolLLf8l/92OxMGaRLbqvIh9wjCHhDXNvk4zsxaTaCpiCunW09qWPrN2zeNSNwRLVBrQQtutA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "10.* || >= 12.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/editions": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-2.3.1.tgz",
+      "integrity": "sha512-ptGvkwTvGdGfC0hfhKg0MT+TRLRKGtUiWGBInxOm5pz7ssADezahjCUaYuZ8Dr+C05FW0AECIIPt4WBxVINEhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "errlop": "^2.0.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=0.8"
       },
       "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+        "url": "https://bevry.me/fund"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/editions/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-cli-babel": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/ember-cli-babel/-/ember-cli-babel-8.2.0.tgz",
+      "integrity": "sha512-8H4+jQElCDo6tA7CamksE66NqBXWs7VNpS3a738L9pZCjg2kXIX4zoyHzkORUqCtr0Au7YsCnrlAMi1v2ALo7A==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "pump": "^3.0.0"
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/plugin-proposal-class-properties": "^7.16.5",
+        "@babel/plugin-proposal-decorators": "^7.20.13",
+        "@babel/plugin-proposal-private-methods": "^7.16.5",
+        "@babel/plugin-proposal-private-property-in-object": "^7.20.5",
+        "@babel/plugin-transform-class-static-block": "^7.22.11",
+        "@babel/plugin-transform-modules-amd": "^7.20.11",
+        "@babel/plugin-transform-runtime": "^7.13.9",
+        "@babel/plugin-transform-typescript": "^7.20.13",
+        "@babel/preset-env": "^7.20.2",
+        "@babel/runtime": "7.12.18",
+        "amd-name-resolver": "^1.3.1",
+        "babel-plugin-debug-macros": "^0.3.4",
+        "babel-plugin-ember-data-packages-polyfill": "^0.1.2",
+        "babel-plugin-ember-modules-api-polyfill": "^3.5.0",
+        "babel-plugin-module-resolver": "^5.0.0",
+        "broccoli-babel-transpiler": "^8.0.0",
+        "broccoli-debug": "^0.6.4",
+        "broccoli-funnel": "^3.0.8",
+        "broccoli-source": "^3.0.1",
+        "calculate-cache-key-for-tree": "^2.0.0",
+        "clone": "^2.1.2",
+        "ember-cli-babel-plugin-helpers": "^1.1.1",
+        "ember-cli-version-checker": "^5.1.2",
+        "ensure-posix-path": "^1.0.2",
+        "resolve-package-path": "^4.0.3",
+        "semver": "^7.3.8"
       },
+      "engines": {
+        "node": "16.* || 18.* || >= 20"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.12.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/ember-template-imports": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ember-template-imports/-/ember-template-imports-4.1.1.tgz",
+      "integrity": "sha512-mnbL3hjo/Ctg7rkBtuYkBRJUn5bDYRQCEZQxmNozRnfoEp2RLSbT6SFJRAFDYXT2OrY+8i821S4kPL1i0QuGIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "broccoli-stew": "^3.0.0",
+        "content-tag": "^2.0.1",
+        "ember-cli-version-checker": "^5.1.2"
+      },
+      "engines": {
+        "node": "16.* || >= 18"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/find-babel-config": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/find-babel-config/-/find-babel-config-2.1.1.tgz",
+      "integrity": "sha512-5Ji+EAysHGe1OipH7GN4qDjok5Z1uw5KAwDCbicU/4wyTZY7CqOCzcWbG7J5ad9mazq67k89fXlbc1MuIfl9uA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.3",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/fs-tree-diff": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fs-tree-diff/-/fs-tree-diff-2.0.1.tgz",
+      "integrity": "sha512-x+CfAZ/lJHQqwlD64pYM5QxWjzWhSjroaVsr8PW831zOApL55qPibed0c+xebaLWVr2BnHFoHdrwOv8pzt8R5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/symlink-or-copy": "^1.2.0",
+        "heimdalljs-logger": "^0.1.7",
+        "object-assign": "^4.1.0",
+        "path-posix": "^1.0.0",
+        "symlink-or-copy": "^1.1.8"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/glob": {
+      "version": "9.3.5",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-9.3.5.tgz",
+      "integrity": "sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "minimatch": "^8.0.2",
+        "minipass": "^4.2.4",
+        "path-scurry": "^1.6.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/istextorbinary": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/istextorbinary/-/istextorbinary-2.6.0.tgz",
+      "integrity": "sha512-+XRlFseT8B3L9KyjxxLjfXSLMuErKDsd8DBNrsaxoViABMEZlOSCstwmw0qpoFX3+U6yWU1yhLudAe6/lETGGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binaryextensions": "^2.1.2",
+        "editions": "^2.2.0",
+        "textextensions": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://bevry.me/fund"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/minimatch": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-8.0.4.tgz",
+      "integrity": "sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/minipass": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.2.8.tgz",
+      "integrity": "sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==",
+      "dev": true,
+      "license": "ISC",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
       },
       "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "yallist": "^4.0.0"
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Glob versions prior to v9 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@appuniversum/ember-appuniversum/node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/rsvp": {
@@ -243,45 +574,23 @@
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "6.* || >= 7.*"
       }
     },
     "node_modules/@appuniversum/ember-appuniversum/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@appuniversum/ember-appuniversum/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.7",
@@ -6370,166 +6679,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "node_modules/@zestia/ember-auto-focus": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/@zestia/ember-auto-focus/-/ember-auto-focus-4.5.1.tgz",
-      "integrity": "sha512-VmiWVJdknqVT2JQMlaRx/ZylDswf+Zsqn9+Gps9SL3sklHQ9V5Qc5/KzO2UxnifdCRVdc4doyVyUCJ8tzj674A==",
-      "deprecated": "Moved to GitHub Packages",
-      "dev": true,
-      "dependencies": {
-        "ember-auto-import": "^2.6.1",
-        "ember-cli-babel": "^7.26.11",
-        "ember-cli-htmlbars": "^6.2.0",
-        "ember-modifier": "^3.2.7"
-      },
-      "engines": {
-        "node": "14.* || 16.* || >= 18"
-      },
-      "peerDependencies": {
-        "ember-source": "^3.28.0 || ^4.0.0"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/ember-cli-typescript": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-5.2.1.tgz",
-      "integrity": "sha512-qqp5TAIuPHxHiGXJKL+78Euyhy0zSKQMovPh8sJpN/ZBYx0H90pONufHR3anaMcp1snVfx4B+mb9+7ijOik8ZA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-to-html": "^0.6.15",
-        "broccoli-stew": "^3.0.0",
-        "debug": "^4.0.0",
-        "execa": "^4.0.0",
-        "fs-extra": "^9.0.1",
-        "resolve": "^1.5.0",
-        "rsvp": "^4.8.1",
-        "semver": "^7.3.2",
-        "stagehand": "^1.0.0",
-        "walk-sync": "^2.2.0"
-      },
-      "engines": {
-        "node": ">= 12.*"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/ember-modifier": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/ember-modifier/-/ember-modifier-3.2.7.tgz",
-      "integrity": "sha512-ezcPQhH8jUfcJQbbHji4/ZG/h0yyj1jRDknfYue/ypQS8fM8LrGcCMo0rjDZLzL1Vd11InjNs3BD7BdxFlzGoA==",
-      "dev": true,
-      "dependencies": {
-        "ember-cli-babel": "^7.26.6",
-        "ember-cli-normalize-entity-name": "^1.0.0",
-        "ember-cli-string-utils": "^1.1.0",
-        "ember-cli-typescript": "^5.0.0",
-        "ember-compatibility-helpers": "^1.2.5"
-      },
-      "engines": {
-        "node": "12.* || >= 14"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/rsvp": {
-      "version": "4.8.5",
-      "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
-      "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
-      "dev": true,
-      "engines": {
-        "node": "6.* || >= 7.*"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/walk-sync": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
-      "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
-      "dev": true,
-      "dependencies": {
-        "@types/minimatch": "^3.0.3",
-        "ensure-posix-path": "^1.1.0",
-        "matcher-collection": "^2.0.0",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": "8.* || >= 10.*"
-      }
-    },
-    "node_modules/@zestia/ember-auto-focus/node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
     "node_modules/abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -11787,6 +11936,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/content-tag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/content-tag/-/content-tag-2.0.1.tgz",
+      "integrity": "sha512-jxsETSDs5NbNwyiDuIp672fUMhUyu8Qxc5MOBOJOcgW/fQESI6o5K1LBDrnEE7Bh810a685lWEZHTF4jQYGEEw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-type": {
       "version": "1.0.5",
@@ -17445,27 +17601,28 @@
       "dev": true
     },
     "node_modules/ember-file-upload": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-7.4.0.tgz",
-      "integrity": "sha512-ZWyUpdtEFZoSeJmeiNf0xdoUxWURbUtViFwPDW5qDZx8GX7245q5vb0kNizTTLuOnTVVly0Nnm7lOPvQhcMg9g==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/ember-file-upload/-/ember-file-upload-8.4.1.tgz",
+      "integrity": "sha512-VeKNNaL5LEo7P6TZqMFXyPSb5kJcjkUG/VNNOll0iZ/EyIXC2fZme64mNyXYheGBLiPk5H1gUsunSNpR6sg1GQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@ember/test-helpers": "^2.9.3",
         "@ember/test-waiters": "^3.0.0",
         "@embroider/addon-shim": "^1.5.0",
         "@embroider/macros": "^1.0.0",
-        "@glimmer/component": "^1.0.4",
-        "@glimmer/tracking": "^1.0.4",
-        "ember-auto-import": "^2.0.0",
-        "ember-modifier": "^3.2.7 || ^4.0.0",
-        "tracked-built-ins": "^3.0.0"
+        "ember-auto-import": "^2.0.0"
       },
       "engines": {
-        "node": "14.* || 16.* || >= 18"
+        "node": "16.* || >= 18"
       },
       "peerDependencies": {
+        "@ember/test-helpers": "^2.9.3 || ^3.0.3",
+        "@glimmer/component": "^1.1.2",
+        "@glimmer/tracking": "^1.1.2",
         "ember-cli-mirage": "*",
-        "miragejs": "*"
+        "ember-modifier": "^3.2.7 || ^4.1.0",
+        "miragejs": "*",
+        "tracked-built-ins": "^3.1.1"
       },
       "peerDependenciesMeta": {
         "ember-cli-mirage": {
@@ -23815,10 +23972,11 @@
       }
     },
     "node_modules/inputmask": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.8.tgz",
-      "integrity": "sha512-1WcbyudPTXP1B28ozWWyFa6QRIUG4KiLoyR6LFHlpT4OfTzRqFfWgHFadNvRuMN1S9XNVz9CdNvCGjJi+uAMqQ==",
-      "dev": true
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/inputmask/-/inputmask-5.0.9.tgz",
+      "integrity": "sha512-s0lUfqcEbel+EQXtehXqwCJGShutgieOaIImFKC/r4reYNvX3foyrChl6LOEvaEgxEbesePIrw1Zi2jhZaDZbQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/inquirer": {
       "version": "7.3.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:ember": "ember test"
   },
   "devDependencies": {
-    "@appuniversum/ember-appuniversum": "^2.18.0",
+    "@appuniversum/ember-appuniversum": "^3.5.0",
     "@babel/eslint-parser": "^7.21.3",
     "@babel/plugin-proposal-decorators": "^7.21.0",
     "@ember/optional-features": "^2.0.0",

--- a/tests/integration/helpers/event-value-test.js
+++ b/tests/integration/helpers/event-value-test.js
@@ -1,0 +1,35 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { fillIn, render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | event-value', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('it calls the handler with the event value', async function (assert) {
+    this.handler = (value) => {
+      assert.step(value);
+    };
+
+    await render(hbs`
+      <label>
+        <input {{on "change" (event-value this.handler)}} />
+      </label>
+    `);
+
+    await fillIn('input', 'foo');
+    assert.verifySteps(['foo']);
+  });
+
+  test('it works with fn + mut', async function (assert) {
+    await render(hbs`
+      <label>
+        <input {{on "change" (event-value (fn (mut this.value)))}} />
+      </label>
+    `);
+
+    assert.strictEqual(this.value, undefined);
+    await fillIn('input', 'foo');
+    assert.strictEqual(this.value, 'foo');
+  });
+});


### PR DESCRIPTION
This resolves all v2 deprecations following the [deprecation guide](https://github.com/appuniversum/ember-appuniversum/pull/459) and updates to Appuniversum v3.

**Notes:**
Appuniversum v3 introduced a new `AuLoader` deprecation, but this PR doesn't resolve that yet since it doesn't break anything and I didn't want to scope creep the PR.