### PR TITLE
[OP-3042] Resolve ember v4 deprecations

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -3,6 +3,9 @@ import Resolver from 'ember-resolver';
 import loadInitializers from 'ember-load-initializers';
 import config from 'frontend-organization-portal/config/environment';
 import './config/custom-inflector-rules';
+import { silenceEmptySyncRelationshipWarnings } from './utils/ember-data';
+
+silenceEmptySyncRelationshipWarnings();
 
 export default class App extends Application {
   modulePrefix = config.modulePrefix;

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -268,8 +268,9 @@ export default class OrganizationsNewController extends Controller {
     newOrganizationModel.legalName = this.currentOrganizationModel.legalName;
     newOrganizationModel.alternativeName =
       this.currentOrganizationModel.alternativeName;
-    newOrganizationModel.organizationStatus =
-      this.currentOrganizationModel.organizationStatus;
+    newOrganizationModel.organizationStatus = this.currentOrganizationModel
+      .belongsTo('organizationStatus')
+      .value();
 
     if (newOrganizationModel.isWorshipAdministrativeUnit) {
       newOrganizationModel.recognizedWorshipType =
@@ -285,7 +286,9 @@ export default class OrganizationsNewController extends Controller {
       newOrganizationModel.isAdministrativeUnit &&
       this.currentOrganizationModel.scope
     ) {
-      newOrganizationModel.scope = this.currentOrganizationModel.scope;
+      newOrganizationModel.scope = this.currentOrganizationModel
+        .belongsTo('scope')
+        .value();
       if (this.currentOrganizationModel.scope.locatedWithin) {
         newOrganizationModel.scope.locatedWithin =
           this.currentOrganizationModel.scope.locatedWithin;
@@ -515,16 +518,13 @@ export default class OrganizationsNewController extends Controller {
 
       yield this.currentOrganizationModel.save();
 
-      let membershipSavePromises =
-        this.currentOrganizationModel.memberships.map((membership) =>
-          membership.save()
-        );
+      let membershipSavePromises = this.memberships.map((membership) =>
+        membership.save()
+      );
       yield Promise.all(membershipSavePromises);
 
       let membershipsOfOrganizationsSavePromises =
-        this.currentOrganizationModel.membershipsOfOrganizations.map(
-          (membership) => membership.save()
-        );
+        this.membershipsOfOrganizations.map((membership) => membership.save());
       yield Promise.all(membershipsOfOrganizationsSavePromises);
 
       const createRelationshipsEndpoint = `/construct-organization-relationships/${this.currentOrganizationModel.id}`;

--- a/app/controllers/organizations/organization/core-data/index.js
+++ b/app/controllers/organizations/organization/core-data/index.js
@@ -51,26 +51,28 @@ export default class OrganizationsOrganizationCoreDataIndexController extends Co
     return identifier?.idName === ID_NAME.OVO;
   }
 
+  get organizationIdentifiers() {
+    return this.model.organization.hasMany('identifiers').value();
+  }
+
   get sharepointIdentifier() {
-    return this.model.organization.identifiers.find((id) =>
+    return this.organizationIdentifiers.find((id) =>
       this.isSharePointIdentifier(id)
     );
   }
 
   get kboIdentifier() {
-    return this.model.organization.identifiers.find((id) =>
-      this.isKboIdentifier(id)
-    );
+    return this.organizationIdentifiers.find((id) => this.isKboIdentifier(id));
   }
 
   get nisIdentifier() {
-    return this.model.organization.identifiers.find((id) =>
+    return this.organizationIdentifiers.find((id) =>
       this.isNisCodeIdentifier(id)
     );
   }
 
   get ovoIdentifier() {
-    return this.model.organization.identifiers.find((id) =>
+    return this.organizationIdentifiers.find((id) =>
       this.isOvoCodeIdentifier(id)
     );
   }

--- a/app/helpers/has-many-value.js
+++ b/app/helpers/has-many-value.js
@@ -1,0 +1,25 @@
+import { assert } from '@ember/debug';
+
+/**
+ * Accesses the loaded data of a hasMany relationship in a sync way so it can be passed around more easily without having to use await first.
+ * This helper assumes the relationship was already loaded before.
+ * @param {unknown} record
+ * @param {string} relationshipName
+ * @returns {unknown[] | null} An array of records if the relationship was loaded, or null if it wasn't
+ */
+export default function hasManyValue(record, relationshipName) {
+  assert(
+    'The record argument should be an EmberData model instance',
+    Boolean(record.hasMany)
+  );
+  assert(
+    'A relationship name is required',
+    typeof relationshipName === 'string' && Boolean(relationshipName)
+  );
+  assert(
+    `The "${record.constructor.name}" class doesn't have a "${relationshipName}" hasMany relationship.`,
+    record.constructor.relationshipsByName?.get(relationshipName)?.kind ===
+      'hasMany'
+  );
+  return record.hasMany(relationshipName).value();
+}

--- a/app/models/membership-role.js
+++ b/app/models/membership-role.js
@@ -40,11 +40,13 @@ export default class MembershipRoleModel extends Model {
   @attr('string') label;
 
   @belongsTo('concept', {
+    async: true,
     inverse: null,
   })
   topConceptOf;
 
   @belongsTo('membership-role', {
+    async: true,
     inverse: null,
   })
   hasBroaderRole;

--- a/app/routes/organizations/new.js
+++ b/app/routes/organizations/new.js
@@ -20,7 +20,7 @@ export default class OrganizationsNewRoute extends Route {
     }
   }
 
-  model() {
+  async model() {
     const structuredIdentifierKBO = this.store.createRecord(
       'structured-identifier'
     );
@@ -39,7 +39,7 @@ export default class OrganizationsNewRoute extends Route {
       structuredIdentifier: structuredIdentifierSharepoint,
     });
 
-    let roles = this.store.query('membership-role', {
+    let roles = await this.store.query('membership-role', {
       'filter[:id:]': [
         MEMBERSHIP_ROLES_MAPPING.HAS_RELATION_WITH.id,
         MEMBERSHIP_ROLES_MAPPING.IS_FOUNDER_OF.id,

--- a/app/templates/organizations/organization/change-events/new.hbs
+++ b/app/templates/organizations/organization/change-events/new.hbs
@@ -304,7 +304,7 @@
                     {{else}}
                       <div class={{if hasError "ember-power-select--error"}}>
                         <PowerSelect
-                          @options={{@model.changeEvent.originalOrganizations}}
+                          @options={{has-many-value @model.changeEvent "originalOrganizations"}}
                           @selected={{this.selectedResultingOrganization}}
                           @onChange={{this.updateResultingOrganizations}}
                           as |organization|

--- a/app/utils/ember-data.js
+++ b/app/utils/ember-data.js
@@ -1,0 +1,15 @@
+import { registerWarnHandler } from '@ember/debug';
+
+export function silenceEmptySyncRelationshipWarnings() {
+  // EmberData displays a warning when we push records with sync relationships where the API only provides a link and no data
+  // Due to legacy reasons EmberData makes the assumption that the relationship is empty, even though it's valid according to the {json:api} spec.
+  // Since the warning is verbose we silence it but it does require some extra workarounds sometimes (reload instead of load for example).
+  // More info: https://github.com/emberjs/data/issues/7584
+  registerWarnHandler((message, options, next) => {
+    if (options.id === 'ds.store.push-link-for-sync-relationship') {
+      return;
+    }
+
+    next(message, options);
+  });
+}

--- a/config/deprecation-workflow.js
+++ b/config/deprecation-workflow.js
@@ -1,16 +1,5 @@
 /* eslint-disable no-undef */
 self.deprecationWorkflow = self.deprecationWorkflow || {};
 self.deprecationWorkflow.config = {
-  workflow: [
-    { handler: 'silence', matchId: 'ember.built-in-components.import' }, // Ember inspector triggers this
-    { handler: 'silence', matchId: 'ember-global' }, // Ember-acmidm-login triggers this
-    { handler: 'silence', matchId: 'ember-modifier.use-destroyables' }, // PowerSelect triggers it
-    { handler: 'silence', matchId: 'ember-modifier.use-modify' }, // PowerSelect triggers it
-    {
-      handler: 'silence',
-      matchId: 'deprecated-run-loop-and-computed-dot-access',
-    }, // Ember-acmidm-login triggers this
-    { handler: 'silence', matchId: 'ember-modifier.no-args-property' }, // PowerSelect triggers it
-    { handler: 'silence', matchId: 'ember-modifier.no-element-property' }, // PowerSelect triggers it
-  ],
+  workflow: [],
 };

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,10 +8,6 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
-    // TODO: remove when updating to Appuniversum v3
-    '@appuniversum/ember-appuniversum': {
-      disableWormholeElement: true,
-    },
     autoprefixer: {
       enabled: true,
       cascade: true,

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,6 +8,10 @@ module.exports = function (defaults) {
     'ember-simple-auth': {
       useSessionSetupMethod: true,
     },
+    // TODO: remove when updating to Appuniversum v3
+    '@appuniversum/ember-appuniversum': {
+      disableWormholeElement: true,
+    },
     autoprefixer: {
       enabled: true,
       cascade: true,

--- a/tests/unit/helpers/has-many-value-test.js
+++ b/tests/unit/helpers/has-many-value-test.js
@@ -1,0 +1,133 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'frontend-organization-portal/tests/helpers';
+import Model, { hasMany } from '@ember-data/model';
+import hasManyValue from 'frontend-organization-portal/helpers/has-many-value';
+
+module('Unit | Helper | hasManyValue', function (hooks) {
+  setupTest(hooks);
+
+  test('it returns (loaded) async relationship data in a sync way', async function (assert) {
+    this.owner.register(
+      'model:foo',
+      class Foo extends Model {
+        @hasMany('bar', {
+          async: true,
+          inverse: null,
+        })
+        bars;
+      }
+    );
+
+    this.owner.register('model:bar', class Bar extends Model {});
+    const store = this.owner.lookup('service:store');
+
+    this.foo = store.createRecord('foo', {
+      bars: [store.createRecord('bar'), store.createRecord('bar')],
+    });
+
+    const result = hasManyValue(this.foo, 'bars');
+    assert.strictEqual(result.length, 2);
+  });
+
+  test("it returns null if the relationship hasn't been loaded yet", async function (assert) {
+    this.owner.register(
+      'model:foo',
+      class Foo extends Model {
+        @hasMany('bar', {
+          async: true,
+          inverse: null,
+        })
+        bars;
+      }
+    );
+
+    this.owner.register('model:bar', class Bar extends Model {});
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: {
+        id: '1',
+        type: 'foo',
+        relationships: {
+          bars: {
+            data: [
+              {
+                id: '1',
+                type: 'bar',
+              },
+              {
+                id: '2',
+                type: 'bar',
+              },
+              {
+                id: '3',
+                type: 'bar',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const foo = store.peekRecord('foo', '1');
+    const result = hasManyValue(foo, 'bars');
+    assert.strictEqual(result, null);
+  });
+
+  test('it returns sideloaded relationship records', async function (assert) {
+    this.owner.register(
+      'model:foo',
+      class Foo extends Model {
+        @hasMany('bar', {
+          async: true,
+          inverse: null,
+        })
+        bars;
+      }
+    );
+
+    this.owner.register('model:bar', class Bar extends Model {});
+    const store = this.owner.lookup('service:store');
+    store.push({
+      data: [
+        {
+          id: '1',
+          type: 'foo',
+          relationships: {
+            bars: {
+              data: [
+                {
+                  id: '1',
+                  type: 'bar',
+                },
+                {
+                  id: '2',
+                  type: 'bar',
+                },
+                {
+                  id: '3',
+                  type: 'bar',
+                },
+              ],
+            },
+          },
+        },
+        {
+          id: '1',
+          type: 'bar',
+        },
+        {
+          id: '2',
+          type: 'bar',
+        },
+        {
+          id: '3',
+          type: 'bar',
+        },
+      ],
+    });
+
+    const foo = store.peekRecord('foo', '1');
+    const result = hasManyValue(foo, 'bars');
+    assert.strictEqual(result.length, 3);
+  });
+});

--- a/tests/unit/models/abstract-validation-model-test.js
+++ b/tests/unit/models/abstract-validation-model-test.js
@@ -161,11 +161,13 @@ class BasicValidationModel extends AbstractValidationModel {
 class BelongsToValidationModel extends AbstractValidationModel {
   @belongsTo('test-validation-model', {
     inverse: null,
+    async: true,
   })
   oneRequired;
 
   @belongsTo('test-validation-model', {
     inverse: null,
+    async: true,
   })
   oneOptional;
 
@@ -180,11 +182,13 @@ class BelongsToValidationModel extends AbstractValidationModel {
 class HasManyValidationModel extends AbstractValidationModel {
   @hasMany('test-validation-model', {
     inverse: null,
+    async: true,
   })
   manyRequired;
 
   @hasMany('test-validation-model', {
     inverse: null,
+    async: true,
   })
   manyOptional;
 

--- a/tests/unit/models/membership-test.js
+++ b/tests/unit/models/membership-test.js
@@ -68,8 +68,8 @@ module('Unit | Model | membership', function (hooks) {
             role: relationRole,
           });
 
-          organization.memberships.pushObject(participant);
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(participant);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -109,7 +109,7 @@ module('Unit | Model | membership', function (hooks) {
             role: role,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -151,7 +151,7 @@ module('Unit | Model | membership', function (hooks) {
             role: role,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -186,7 +186,7 @@ module('Unit | Model | membership', function (hooks) {
             role: role,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -230,7 +230,7 @@ module('Unit | Model | membership', function (hooks) {
             role: founderRole,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -274,8 +274,8 @@ module('Unit | Model | membership', function (hooks) {
             role: role,
           });
 
-          organization.memberships.pushObject(founder);
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(founder);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -308,7 +308,7 @@ module('Unit | Model | membership', function (hooks) {
               role: role,
             });
 
-            organization.memberships.pushObject(model);
+            (await organization.memberships).push(model);
 
             const isValid = await model.validate({
               creatingNewOrganization: true,
@@ -349,7 +349,7 @@ module('Unit | Model | membership', function (hooks) {
               role: relationRole,
             });
 
-            organization.memberships.pushObject(model);
+            (await organization.memberships).push(model);
 
             const isValid = await model.validate({
               creatingNewOrganization: true,
@@ -387,7 +387,7 @@ module('Unit | Model | membership', function (hooks) {
             role: role,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,
@@ -431,7 +431,7 @@ module('Unit | Model | membership', function (hooks) {
             role: relationRole,
           });
 
-          organization.memberships.pushObject(model);
+          (await organization.memberships).push(model);
 
           const isValid = await model.validate({
             creatingNewOrganization: true,


### PR DESCRIPTION
This resolves any EmberData related deprecations I could find.

I clicked through the app as best as I could, but I'm unfamiliar with the app so I might have missed some flows.

To make testing easier, you could use the following deprecation-workflow config to hide the noisy non-EmberData deprecations:

<details>
<summary>Config</summary>

```js
self.deprecationWorkflow.config = {
  workflow: [
    // TODO: resolve before updating to Appuniversum v4
    {
      handler: 'silence',
      matchId: '@appuniversum/ember-appuniversum.au-loader-visible-by-default',
    },
    // TODO: resolve before updating to Appuniversum v4
    {
      handler: 'silence',
      matchId: '@appuniversum/ember-appuniversum.au-button-loading-message',
    },
    { handler: 'silence', matchId: 'ember-resources.util.trackedTask' }, // TODO: Resolve before updating ember-resources
    { handler: 'silence', matchId: 'ember-resources.class-based' }, // TODO: Resolve before updating ember-resources
  ],
};
```
</details>

~~(Builds on #636 so draft until that's merged)~~