### PR TITLE
[OP-3352] Fix an issue where the change event select options weren't always properly loaded

### DIFF
--- a/app/components/change-event-type-select.js
+++ b/app/components/change-event-type-select.js
@@ -25,7 +25,7 @@ export default class ChangeEventTypeSelectComponent extends Component {
   }
 
   @task *loadChangeEventTypesTask() {
-    let types = yield this.store.findAll('change-event-type');
+    let types = yield this.store.findAll('change-event-type', { reload: true });
 
     let classification = yield this.args.organizationClassification;
     if (classification.id == CLASSIFICATION.WORSHIP_SERVICE.id) {


### PR DESCRIPTION
`store.findAll` doesn't wait for the background reload to finish if the store already contains records of the specific type that is requested. Since we only run the `loadChangeEventTypesTask` on component creation, the full data set is never used.

By adding the `reload` option we ensure that the full dataset is loaded properly.