### PR TITLE
fix: correctly calculate total sum of finance percentages for local involvements

### DIFF
--- a/app/models/local-involvement.js
+++ b/app/models/local-involvement.js
@@ -80,6 +80,7 @@ export default class LocalInvolvementModel extends AbstractValidationModel {
           .external(async (value, helpers) => {
             const otherLocalInvolvements =
               await this.getOtherLocalInvolvements();
+
             const sumOtherPercentages = otherLocalInvolvements.reduce(
               (percentageAcc, involvement) =>
                 percentageAcc + Number(involvement.percentage),
@@ -144,14 +145,11 @@ export default class LocalInvolvementModel extends AbstractValidationModel {
    */
   async getOtherLocalInvolvements() {
     const worshipAdministrativeUnit = await this.worshipAdministrativeUnit;
-    let relatedLocalInvolvements = await this.store.query('local-involvement', {
-      filter: {
-        'worship-administrative-unit': {
-          id: worshipAdministrativeUnit.get('id'),
-        },
-      },
-    });
+    const relatedLocalInvolvements =
+      await worshipAdministrativeUnit.involvements;
 
-    return relatedLocalInvolvements.filter((elem) => elem.id !== this.id);
+    // Note: do not filter on id as this also deals with unsaved elements that
+    // do not have an id yet.
+    return relatedLocalInvolvements.filter((elem) => elem !== this);
   }
 }

--- a/tests/unit/models/local-involvement-test.js
+++ b/tests/unit/models/local-involvement-test.js
@@ -102,6 +102,150 @@ module('Unit | Model | local involvement', function (hooks) {
       });
     });
 
+    test('it does not return an error when the percentage is 100', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.SUPERVISORY,
+      });
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: 100,
+      });
+
+      const getOtherLocalInvolvementsStub = sinon.stub(
+        model,
+        'getOtherLocalInvolvements'
+      );
+      getOtherLocalInvolvementsStub.resolves([]);
+
+      const isValid = await model.validate();
+
+      assert.true(isValid);
+    });
+
+    test('it does not return an error when the sum of percentages is 100', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.SUPERVISORY,
+      });
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: 50,
+      });
+
+      const midFinancialInvolvementType = this.store().createRecord(
+        'involvement-type',
+        {
+          id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+        }
+      );
+      const otherModel = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        midFinancialInvolvementType,
+        percentage: 50,
+      });
+
+      const getOtherLocalInvolvementsStub = sinon.stub(
+        model,
+        'getOtherLocalInvolvements'
+      );
+      getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+      const isValid = await model.validate();
+
+      assert.true(isValid);
+    });
+
+    test('it does return an error when the sum of percentages is above 100', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.SUPERVISORY,
+      });
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: 50,
+      });
+
+      const midFinancialInvolvementType = this.store().createRecord(
+        'involvement-type',
+        {
+          id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+        }
+      );
+      const otherModel = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        midFinancialInvolvementType,
+        percentage: 70,
+      });
+
+      const getOtherLocalInvolvementsStub = sinon.stub(
+        model,
+        'getOtherLocalInvolvements'
+      );
+      getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 1);
+      assert.propContains(model.error, {
+        percentage: {
+          message: 'Het totaal van alle percentages moet gelijk zijn aan 100',
+        },
+      });
+    });
+
+    test('it does return an error when the sum of percentages is below 100', async function (assert) {
+      const administrativeUnit = this.store().createRecord(
+        'administrative-unit'
+      );
+      const involvementType = this.store().createRecord('involvement-type', {
+        id: INVOLVEMENT_TYPE.SUPERVISORY,
+      });
+      const model = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        involvementType,
+        percentage: 10,
+      });
+
+      const midFinancialInvolvementType = this.store().createRecord(
+        'involvement-type',
+        {
+          id: INVOLVEMENT_TYPE.MID_FINANCIAL,
+        }
+      );
+      const otherModel = this.store().createRecord('local-involvement', {
+        administrativeUnit,
+        midFinancialInvolvementType,
+        percentage: 20,
+      });
+
+      const getOtherLocalInvolvementsStub = sinon.stub(
+        model,
+        'getOtherLocalInvolvements'
+      );
+      getOtherLocalInvolvementsStub.resolves([otherModel]);
+
+      const isValid = await model.validate();
+
+      assert.false(isValid);
+      assert.strictEqual(Object.keys(model.error).length, 1);
+      assert.propContains(model.error, {
+        percentage: {
+          message: 'Het totaal van alle percentages moet gelijk zijn aan 100',
+        },
+      });
+    });
+
     module('existsOtherSupervisoryLocalInvolvement', function () {
       test('it returns true when there is another SUPERVISORY local involvement', async function (assert) {
         const administrativeUnit = this.store().createRecord(


### PR DESCRIPTION
The validation that the total sum of financing percentages for local involvements is exactly 100 contained an error where any newly added local involvements were not considered in the calculation.

## Steps to reproduce the original bug
1. Log in as worship editor
2. Select a worship service in the organisation overview
3. Navigate to the “Betrokken lokale besturen” page
4. Click the “Bewerk” button in the top right corner
5. Add a new local involvement by clicking the “+ Voeg nieuw betrokken lokaal bestuur toe” button on the bottom
6. Fill in the necessary fields: select “Mede-financierend” as type of involvement, enter a percentage above 0
7. Make sure the total sum of the percentages equals 100
8. Click the save button in the top right corner
9. On most percentage fields an error should be shown concerning an incorrect total percentage sum (Full error message: 'Het totaal van alle percentages moet gelijk zijn aan 100')

## Problem description
In order to calculate the sum of the finance percentages in the local involvement model validation, the other relevant local involvements must be retrieved. Initially this was done with a query on the store for local involvements, filtered on the identifier of the worship administrative unit related to the local involvement being validated.

This way of retrieving local involvements resulted in that any newly added, unsaved local involvement was not retrieved and thus not included in the sum calculation.

## Proposed solution
Instead of querying the store, we can use the `involvements` relationship of the worship administrative unit related to the local involvement being validated. This relationship includes all previous as well as newly added local involvements. Resulting in a correct calculation of the total financing percentage.

## Related tickets
OP-3373