### PR TITLE
fix: remove membership from array before destroying record

### DIFF
--- a/app/controllers/organizations/organization/related-organizations/edit.js
+++ b/app/controllers/organizations/organization/related-organizations/edit.js
@@ -62,6 +62,7 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
 
   @action
   reallyRemoveMembership(membership) {
+    this.memberships.removeObject(membership);
     membership.deleteRecord();
     this.removingFounder = false;
   }

--- a/app/models/administrative-unit.js
+++ b/app/models/administrative-unit.js
@@ -93,7 +93,7 @@ export default class AdministrativeUnitModel extends OrganizationModel {
             ...PoliceZoneCodeList,
             ...AssistanceZoneCodeList,
             ...WorshipServiceCodeList,
-            ...CentralWorshipServiceCodeList,
+            ...CentralWorshipServiceCodeList
           ),
           then: validateHasManyNotEmptyRequired(REQUIRED_MESSAGE),
           otherwise: validateHasManyOptional(),


### PR DESCRIPTION
Memberships were not actually removed from the `memberships` array, only the
record was deleted. As a result an `TypeError` was thrown when trying to save
the form after adding and removing a new membership. This error was caused by
the `save` function trying to validate the deleted the membership record as it
is still referenced by the `memberships` array. Explicitly removing a membership
from the `memberships` array before deleting the record fixes this issue.

## Steps to reproduce the bug
0. Make sure your browser's developer console is open
1. Select an organisation and navigate to its “Gerelateerde organisaties” page.
2. Click the edit button in the top right corner.
3. Add a new membership using the “+ Voeg nieuwe gerelateerde organisatie toe”
   button on the bottom of the edit form.
4. Remove the newly added entry using the “Verwijder” button in the last column
   of the row.
5. Save the form by clicking the “Opslaan” button in the top right corner
6. The page should crash with and a TypeError should appear in the console

## Related ticket
- OP-3371