### PR TITLE
fix: corrected the possible relationships between provinces and other organisations

### DIFF
--- a/app/constants/memberships.js
+++ b/app/constants/memberships.js
@@ -55,6 +55,14 @@ export const allowedParticipationMemberships = [
     organizations: [...PevaCodeList],
     members: [...IGSCodeList],
   },
+  {
+    organizations: [...AgbCodeList],
+    members: [...MunicipalityCodeList],
+  },
+  {
+    organizations: [...ApbCodeList],
+    members: [...ProvinceCodeList],
+  },
 ];
 
 export const allowedfoundingMemberships = [
@@ -64,7 +72,7 @@ export const allowedfoundingMemberships = [
   },
   {
     organizations: [...ApbCodeList],
-    members: [...MunicipalityCodeList],
+    members: [...ProvinceCodeList],
   },
   {
     organizations: [...PevaMunicipalityCodeList],
@@ -104,6 +112,16 @@ export const allowedHasRelationWithMemberships = [
       ...AssistanceZoneCodeList,
     ],
   },
+  {
+    organizations: [...ProvinceCodeList],
+    members: [
+      ...ApbCodeList,
+      ...MunicipalityCodeList,
+      ...PevaProvinceCodeList,
+      ...OCMWCodeList,
+    ],
+  },
+  { organizations: [...AgbCodeList], members: [...ProvinceCodeList] },
   {
     organizations: [
       ...CentralWorshipServiceCodeList,

--- a/tests/unit/models/administrative-unit-test.js
+++ b/tests/unit/models/administrative-unit-test.js
@@ -399,7 +399,7 @@ module('Unit | Model | administrative unit', function (hooks) {
 
   module('founderClassifications', function () {
     [
-      [CLASSIFICATION.APB, [CLASSIFICATION.MUNICIPALITY.id]],
+      [CLASSIFICATION.APB, [CLASSIFICATION.PROVINCE.id]],
       [CLASSIFICATION.AGB, [CLASSIFICATION.MUNICIPALITY.id]],
       [
         CLASSIFICATION.PEVA_MUNICIPALITY,

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -466,7 +466,6 @@ module('Unit | Model | organization', function (hooks) {
           ...AssistanceZoneCodeList,
         ],
       ],
-      [CLASSIFICATION.DISTRICT, [...ProvinceCodeList]],
       [
         CLASSIFICATION.PROVINCE,
         [

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -3,9 +3,20 @@ import { setupTest } from 'ember-qunit';
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import { MEMBERSHIP_ROLES_MAPPING } from 'frontend-organization-portal/models/membership-role';
 import {
+  AgbCodeList,
+  ApbCodeList,
+  AssistanceZoneCodeList,
+  CentralWorshipServiceCodeList,
   IGSCodeList,
+  MunicipalityCodeList,
   OcmwAssociationCodeList,
+  OCMWCodeList,
   PevaCodeList,
+  PevaProvinceCodeList,
+  PoliceZoneCodeList,
+  ProvinceCodeList,
+  RepresentativeBodyCodeList,
+  WorshipServiceCodeList,
 } from 'frontend-organization-portal/constants/Classification';
 
 module('Unit | Model | organization', function (hooks) {
@@ -230,7 +241,7 @@ module('Unit | Model | organization', function (hooks) {
     [
       [
         CLASSIFICATION.MUNICIPALITY,
-        [...IGSCodeList, ...OcmwAssociationCodeList],
+        [...IGSCodeList, ...OcmwAssociationCodeList, ...AgbCodeList],
       ],
       [CLASSIFICATION.OCMW, [...IGSCodeList, ...OcmwAssociationCodeList]],
       [CLASSIFICATION.AGB, [...IGSCodeList]],
@@ -305,7 +316,7 @@ module('Unit | Model | organization', function (hooks) {
     });
 
     [
-      [CLASSIFICATION.APB, [CLASSIFICATION.MUNICIPALITY.id]],
+      [CLASSIFICATION.APB, [CLASSIFICATION.PROVINCE.id]],
       [CLASSIFICATION.AGB, [CLASSIFICATION.MUNICIPALITY.id]],
       [
         CLASSIFICATION.PEVA_MUNICIPALITY,
@@ -403,10 +414,13 @@ module('Unit | Model | organization', function (hooks) {
         CLASSIFICATION.MUNICIPALITY,
         [
           CLASSIFICATION.AGB.id,
-          CLASSIFICATION.APB.id,
           CLASSIFICATION.PEVA_MUNICIPALITY.id,
           ...OcmwAssociationCodeList,
         ],
+      ],
+      [
+        CLASSIFICATION.PROVINCE,
+        [CLASSIFICATION.PEVA_PROVINCE.id, CLASSIFICATION.APB.id],
       ],
       [CLASSIFICATION.OCMW, [...OcmwAssociationCodeList]],
       [
@@ -434,6 +448,64 @@ module('Unit | Model | organization', function (hooks) {
         const membership = this.store().createRecord('membership', {
           role: founderRole,
           member: model,
+        });
+
+        const result = model.getClassificationCodesForMembership(membership);
+
+        assert.deepEqual(result.sort(), classificationCodes.sort());
+      });
+    });
+
+    [
+      [
+        CLASSIFICATION.MUNICIPALITY,
+        [
+          ...AgbCodeList,
+          ...IGSCodeList,
+          ...PoliceZoneCodeList,
+          ...AssistanceZoneCodeList,
+        ],
+      ],
+      [CLASSIFICATION.DISTRICT, [...ProvinceCodeList]],
+      [
+        CLASSIFICATION.PROVINCE,
+        [
+          ...ApbCodeList,
+          ...MunicipalityCodeList,
+          ...PevaProvinceCodeList,
+          ...OCMWCodeList,
+        ],
+      ],
+      [CLASSIFICATION.AGB, [...ProvinceCodeList]],
+      [
+        CLASSIFICATION.CENTRAL_WORSHIP_SERVICE,
+        [...WorshipServiceCodeList, ...RepresentativeBodyCodeList],
+      ],
+      [
+        CLASSIFICATION.WORSHIP_SERVICE,
+        [...CentralWorshipServiceCodeList, ...RepresentativeBodyCodeList],
+      ],
+      [
+        CLASSIFICATION.REPRESENTATIVE_BODY,
+        [...WorshipServiceCodeList, ...CentralWorshipServiceCodeList],
+      ],
+    ].forEach(([cl, classificationCodes]) => {
+      test(`it should allow a(n) ${cl.label} to have a relation with the correct organizations`, async function (assert) {
+        const classification = this.store().createRecord(
+          'administrative-unit-classification-code',
+          cl,
+        );
+        const model = this.store().createRecord('administrative-unit', {
+          id: '123',
+          classification,
+        });
+        const role = this.store().createRecord(
+          'membership-role',
+          MEMBERSHIP_ROLES_MAPPING.HAS_RELATION_WITH,
+        );
+        const membership = this.store().createRecord('membership', {
+          role: role,
+          organization: model,
         });
 
         const result = model.getClassificationCodesForMembership(membership);


### PR DESCRIPTION
Previously the relationships that could be defined for provinces were incomplete. As a result a user could not add relationships involving provinces. This PR corrects this situation by allowing additional relationships for provinces.

A province can act as a member in the following types of memberships:

| Membership role | Organisation classification |
| --- | ---|
| is founder of | APB |
| is founder of | PEVA province |
| participates in | APB |
| has a relation with | APB |
| has a relation with | municipality |
| has a relation with | district |
| has a relation with | PEVA province |
| has a relation with | OCMW |

A province **cannot** have a
- founding organisation
- participant

## Related tickets
- OP-3324