### PR TITLE
fix: loosen up membership validations for vereniging en vennootschap

### DIFF
--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -27,7 +27,7 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
       memberships: Joi.when(Joi.ref('$creatingNewOrganization'), {
         is: Joi.exist().valid(true),
         then: Joi.when('classification.id', {
-          is: Joi.string().valid(
+          is: Joi.exist().valid(
             ...CorporationOtherCodeList,
             ...AssociationOtherCodeList,
           ),

--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -29,7 +29,7 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
         then: Joi.when('classification.id', {
           is: Joi.string().valid(
             ...CorporationOtherCodeList,
-            ...AssociationOtherCodeList
+            ...AssociationOtherCodeList,
           ),
           then: validateHasManyOptional(),
           otherwise: validateHasManyNotEmptyRequired(REQUIRED_MESSAGE),

--- a/app/models/registered-organization.js
+++ b/app/models/registered-organization.js
@@ -16,13 +16,24 @@ export default class RegisteredOrganizationModel extends OrganizationModel {
   get validationSchema() {
     const REQUIRED_MESSAGE = 'Selecteer een optie';
     return super.validationSchema.append({
-      // NOTE:The requested functionality was to *not* validate memberships of
-      // already existing organizations. When creating a new organization a
-      // mandatory membership is enforced by providing a `true` value for
-      // `creatingNewOrganization`.
+      // NOTE: The requested functionality was to *not* validate memberships of
+      // already existing organizations.
+      // 1. For existing organizations: memberships are not validated (optional).
+      // 2. For new organizations:
+      //    a. 'Vennootschappen' and 'Verenigingen' (corporations and associations):
+      //       memberships are optional.
+      //    b. All other types: memberships are mandatory.
+      // The creatingNewOrganization flag (set to true) triggers validation for new organizations.'
       memberships: Joi.when(Joi.ref('$creatingNewOrganization'), {
         is: Joi.exist().valid(true),
-        then: validateHasManyNotEmptyRequired(REQUIRED_MESSAGE),
+        then: Joi.when('classification.id', {
+          is: Joi.string().valid(
+            ...CorporationOtherCodeList,
+            ...AssociationOtherCodeList
+          ),
+          then: validateHasManyOptional(),
+          otherwise: validateHasManyNotEmptyRequired(REQUIRED_MESSAGE),
+        }),
         otherwise: validateHasManyOptional(),
       }),
     });

--- a/tests/unit/models/registered-organization-test.js
+++ b/tests/unit/models/registered-organization-test.js
@@ -43,6 +43,30 @@ module('Unit | Model | registered organization', function (hooks) {
     });
 
     [
+      CLASSIFICATION.ASSOCIATION_OTHER,
+      CLASSIFICATION.CORPORATION_OTHER,
+    ].forEach((cl) => {
+      test(`it should not return an extra error creating an empty ${cl.label} model`, async function (assert) {
+        const classification = this.store().createRecord(
+          'registered-organization-classification-code',
+          cl,
+        );
+        const model = this.store().createRecord('registered-organization', {
+          classification,
+        });
+
+        const isValid = await model.validate({ creatingNewOrganization: true });
+
+        assert.false(isValid);
+        assert.strictEqual(Object.keys(model.error).length, 2);
+        assert.propContains(model.error, {
+          legalName: { message: 'Vul de juridische naam in' },
+          organizationStatus: { message: 'Selecteer een optie' },
+        });
+      });
+    });
+
+    [
       CLASSIFICATION.ZIEKENHUISVERENIGING,
       CLASSIFICATION.VERENIGING_OF_VENNOOTSCHAP_VOOR_SOCIALE_DIENSTVERLENING,
       CLASSIFICATION.WOONZORGVERENIGING_OF_WOONZORGVENNOOTSCHAP,


### PR DESCRIPTION
## ID
OP-3388

## Description

Fixes the bug when creating new verenigingen or vennootschappen of failing validations. The memberships validations was too strict and was mandatory for every type, but since verenigingen and vennootschappen don't need it, we allow the memberships to be empty then.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

## How to test

1. Create 2 new organisations:
- vennootschap
- vereniging
2. Fill in the required fields
3. Save and verify that the organisations get created successfully without the validations failing.

