### PR TITLE
fix: do not save duplicate relationships between organizations

### DIFF
--- a/app/controllers/organizations/organization/related-organizations/edit.js
+++ b/app/controllers/organizations/organization/related-organizations/edit.js
@@ -140,6 +140,15 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
     yield Promise.all(validationPromises);
 
     if (!this.hasValidationErrors) {
+      // Filter duplicate memberships, this means memberships that have the same
+      // member, organization, and role.
+      // Note: Do *not* move this filtering earlier in the function, that
+      // results in nasty interactions/errors when a validation fails.
+      this.memberships = this.memberships.filter(
+        (membership, index, memberships) =>
+          index === memberships.findIndex((m) => membership.equals(m)),
+      );
+
       let savePromises = this.memberships.map((membership) => {
         membership.save();
       });

--- a/app/models/membership.js
+++ b/app/models/membership.js
@@ -53,7 +53,7 @@ export default class MembershipModel extends AbstractValidationModel {
         //     ```
         //     someMembership.validate({creatingNewOrganization: true})
         //     ```
-        // - If this validation for use during editing: For OCMW associations
+        // - If this validation is used during editing: For OCMW associations
         //   and PEVAs a founding organisation is normally mandatory. But the
         //   available business data when onboarding them was incomplete in this
         //   respect. Therefore, we opted to relax this rule for the OCMW
@@ -134,5 +134,20 @@ export default class MembershipModel extends AbstractValidationModel {
         return this.role.get('inverseOpLabel');
       }
     }
+  }
+
+  /**
+   * Check whether this membership is equal to a given one. Two memberships are
+   * considered equal their respective organizatios, members, and roles have the
+   * same id.
+   * @param {MembershipModel} membership - The membership to compare with.
+   * @return True if this membership are equal, false otherwise.
+   */
+  equals(membership) {
+    return (
+      this.organization.id === membership.organization.id &&
+      this.member.id === membership.member.id &&
+      this.role.id === membership.role.id
+    );
   }
 }

--- a/tests/unit/models/membership-test.js
+++ b/tests/unit/models/membership-test.js
@@ -459,4 +459,191 @@ module('Unit | Model | membership', function (hooks) {
       });
     });
   });
+
+  module('equals', function () {
+    test('Membership equality is reflexive', function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const model = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const areEqual = model.equals(model);
+      assert.true(areEqual);
+    });
+
+    test('Membership equality is symmetric', function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const model = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const other = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const modelEqualsOther = model.equals(other);
+      const otherEqualsModel = other.equals(model);
+      assert.equal(modelEqualsOther, otherEqualsModel);
+    });
+
+    test('Membership equality is transitive', function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const membershipOne = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const membershipTwo = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const membershipThree = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const oneEqualsTwo = membershipOne.equals(membershipTwo);
+      const twoEqualsThree = membershipTwo.equals(membershipThree);
+      assert.equal(oneEqualsTwo, twoEqualsThree);
+    });
+
+    test('it should return true when memberships have the same organization, member and role', async function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const membershipOne = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+      const membershipTwo = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: role,
+      });
+
+      const areEqual = membershipOne.equals(membershipTwo);
+      assert.true(areEqual);
+    });
+
+    test('it should return false when memberships have a different role', async function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const roleOne = this.store().createRecord('membership-role', {
+        id: 'role-one',
+      });
+      const roleTwo = this.store().createRecord('membership-role', {
+        id: 'role-two',
+      });
+
+      const membershipOne = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: roleOne,
+      });
+      const membershipTwo = this.store().createRecord('membership', {
+        organization: organization,
+        member: member,
+        role: roleTwo,
+      });
+
+      const areEqual = membershipOne.equals(membershipTwo);
+      assert.false(areEqual);
+    });
+
+    test('it should return false when memberships have a different organizations', async function (assert) {
+      const organizationOne = this.store().createRecord('organization', {
+        id: 'organization-one',
+      });
+      const organizationTwo = this.store().createRecord('organization', {
+        id: 'prganization-two',
+      });
+      const member = this.store().createRecord('organization', {
+        id: 'member',
+      });
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const membershipOne = this.store().createRecord('membership', {
+        organization: organizationOne,
+        member: member,
+        role: role,
+      });
+      const membershipTwo = this.store().createRecord('membership', {
+        organization: organizationTwo,
+        member: member,
+        role: role,
+      });
+
+      const areEqual = membershipOne.equals(membershipTwo);
+      assert.false(areEqual);
+    });
+
+    test('it should return false when memberships have a different members', async function (assert) {
+      const organization = this.store().createRecord('organization', {
+        id: 'organization',
+      });
+      const memberOne = this.store().createRecord('organization', {
+        id: 'member-one',
+      });
+      const memberTwo = this.store().createRecord('organization', {
+        id: 'member-two',
+      });
+
+      const role = this.store().createRecord('membership-role', { id: 'role' });
+
+      const membershipOne = this.store().createRecord('membership', {
+        organization: organization,
+        member: memberOne,
+        role: role,
+      });
+      const membershipTwo = this.store().createRecord('membership', {
+        organization: organization,
+        member: memberTwo,
+        role: role,
+      });
+
+      const areEqual = membershipOne.equals(membershipTwo);
+      assert.false(areEqual);
+    });
+  });
 });

--- a/tests/unit/models/membership-test.js
+++ b/tests/unit/models/membership-test.js
@@ -503,7 +503,7 @@ module('Unit | Model | membership', function (hooks) {
 
       const modelEqualsOther = model.equals(other);
       const otherEqualsModel = other.equals(model);
-      assert.equal(modelEqualsOther, otherEqualsModel);
+      assert.strictEqual(modelEqualsOther, otherEqualsModel);
     });
 
     test('Membership equality is transitive', function (assert) {
@@ -535,7 +535,7 @@ module('Unit | Model | membership', function (hooks) {
 
       const oneEqualsTwo = membershipOne.equals(membershipTwo);
       const twoEqualsThree = membershipTwo.equals(membershipThree);
-      assert.equal(oneEqualsTwo, twoEqualsThree);
+      assert.strictEqual(oneEqualsTwo, twoEqualsThree);
     });
 
     test('it should return true when memberships have the same organization, member and role', async function (assert) {


### PR DESCRIPTION
Add functionality to prevent that users can add duplicate relationships between
organizations.

## Issue
It should not be allowed that users add duplicate relations between
organizations. In this context, duplicate relationships mean `membership`s that
have the same `member`, `organization`, and `role`. Previously, there was no
check on this and they would just be saved to the triplestore.

## Proposed solution
Before actually saving the (edited) memberships, filter out any duplicate
memberships such that they are not persisted to the triplestore. This does not
require any user interaction (beyond clicking the save button).

Note: the functionality initially requested was to show error messages to the
user informing them of duplicate relationships, and letting them resolve these
errors themselves. This was later on simplified to the solution applied in this
PR.

## Related tickets
- OP-3323
- OP-3265