### PR TITLE
fix: ensure `memberships` is an EmberArray while it can be edited

### DIFF
--- a/app/controllers/organizations/organization/related-organizations/edit.js
+++ b/app/controllers/organizations/organization/related-organizations/edit.js
@@ -130,6 +130,9 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
         }
       }),
     );
+    // Convert back to an EmberArray, otherwise edits performed after a failed
+    // validation cause errors.
+    this.memberships = A(this.memberships.map((e) => e));
 
     let organization = this.model.organization;
 


### PR DESCRIPTION
The logic to check and correct the `member` and `organization` assignments
before saving `memberships` has the unintended side effect of converting this
from an EmberArray to a regular one.  As a result, any edit after an
unsuccessful save will throw a `TypeError`s as the used `pushObject` and
`removeObject` functions are not defined for regular arrays.

To fix this `memberships` is reconverted to an EmberArray before further
processing within the `save` function.

## Steps to reproduce the bug
0. Open the browser’s developer console.
1. Log in to OP with editor rights
2. Select an organization from the overview table on the index page
3. Navigate to the selected organization’s “Gerelateerde organisaties” page
4. Click the edit button in the top right corner
5. Click the “+ Voeg nieuwe gerelateerde organisatie toe” on the bottom of the
   edit page
6. Do **not** fill in any information in the new row, but click the save button
   on the top right. As expected error messages about empty fields should
   appear.
7. Either try to remove an a row from the table by clicking the “Verwijder”
   button, or try to add another new element by clicking the “+ Voeg nieuwe
   gerelateerde organisatie toe”.
8. A `TypeError` should appear in the developer console.

## Related ticket
- OP-3403