### PR TITLE
fix: prevent the deletion of a membership being forgotten

### DIFF
--- a/app/controllers/organizations/organization/related-organizations/edit.js
+++ b/app/controllers/organizations/organization/related-organizations/edit.js
@@ -62,8 +62,18 @@ export default class OrganizationsOrganizationRelatedOrganizationsEditController
 
   @action
   reallyRemoveMembership(membership) {
-    this.memberships.removeObject(membership);
-    membership.deleteRecord();
+    // Note, The `save` function below depends on the contents of the
+    // memberships array to persist the necessary changes:
+    // - do *not* remove any already persisted memberships from the array as
+    //   this will cause their deletion to "forgotten" in the `save` function.
+    // - do remove newly added memberships that have not been persisted yet.
+    //   Otherwise, they can result in failing validations or errors.
+    if (membership.isNew) {
+      this.memberships.removeObject(membership);
+      membership.destroyRecord();
+    } else {
+      membership.deleteRecord();
+    }
     this.removingFounder = false;
   }
 


### PR DESCRIPTION
The bug fix in #642 was applied too broadly. The `save` function relies on the
information in the `memberships` array to persist the necessary changes.
Consequently, removing elements from this array results in any changes,
including their deletion, to be forgotten.

We do explicitly remove new, not yet persisted, memberships from the array and
immediately destroy them. Otherwise, they can cause failed validations, they can
be incomplete, or cause errors being thrown.

## Related tickets
- OP-3406
- OP-3371