### PR TITLE
fix: add embroider/macros as dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@ember/optional-features": "^2.1.0",
         "@ember/string": "^3.1.1",
         "@ember/test-helpers": "^3.3.0",
+        "@embroider/macros": "^1.16.6",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
         "@lblod/ember-acmidm-login": "2.1.0",
@@ -4382,13 +4383,12 @@
       "dev": true
     },
     "node_modules/@embroider/macros": {
-      "version": "1.16.5",
-      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.5.tgz",
-      "integrity": "sha512-Oz8bUZvZzOV1Gk3qSgIzZJJzs6acclSTcEFyB+KdKbKqjTC3uebn53aU2gAlLU7/YdTRZrg2gNbQuwAp+tGkGg==",
+      "version": "1.16.6",
+      "resolved": "https://registry.npmjs.org/@embroider/macros/-/macros-1.16.6.tgz",
+      "integrity": "sha512-aSdRetg0vY3c70G/3K85fOSlGtDzSV4ozwF9qD8ToQB+4RLZusxwItnctWEa+MKkhAYB6rbFiQ+bhFwEnaEazg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@embroider/shared-internals": "2.6.2",
+        "@embroider/shared-internals": "2.6.3",
         "assert-never": "^1.2.1",
         "babel-import-util": "^2.0.0",
         "ember-cli-babel": "^7.26.6",
@@ -4981,11 +4981,10 @@
       "dev": true
     },
     "node_modules/@embroider/shared-internals": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.2.tgz",
-      "integrity": "sha512-jL3Bjn8C73AUBlTex+VixP7YmqvPNN/BZFB85odTstzLFOuR8y2mmGiuWbq17qNuFyoxc6xtndMnAeqwCXBNkA==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/@embroider/shared-internals/-/shared-internals-2.6.3.tgz",
+      "integrity": "sha512-wyFQNSqN+RZWg5ckqsk0Qfun433aEd70L6sc16sY4FFf/AzDnolmc0t3eR7lkdyxltYSrO5eqkFN7hW7l/glaw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "babel-import-util": "^2.0.0",
         "debug": "^4.3.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@ember/optional-features": "^2.1.0",
     "@ember/string": "^3.1.1",
     "@ember/test-helpers": "^3.3.0",
+    "@embroider/macros": "^1.16.6",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
     "@lblod/ember-acmidm-login": "2.1.0",


### PR DESCRIPTION
The ember-inspector plugin's data tab was broken due an error occurring when
trying to access it:
```
Error message: Could not find module `@embroider/macros` imported from `frontend-organization-portal/data-adapter`
Stack trace: missingModule@http://localhost:4200/assets/vendor.js:266:11
```

Adding `@embroider/macros` as a dependency resolves this issue and allows to use
the data functionality of ember-inspector again.


Credit to @windvis debugging this issue.