### PR TITLE
fix: 'meldt' typo

### DIFF
--- a/app/templates/organizations/index.hbs
+++ b/app/templates/organizations/index.hbs
@@ -167,7 +167,7 @@
             <p>
               Er werden geen zoekresultaten gevonden. Kijk na op spelfouten, of
               probeer een andere zoekopdracht. Indien een organisatie ontbreekt,
-              meldt dit aan
+              meld dit aan
               <a
                 class="au-c-link"
                 href="mailto:{{config 'contactEmail'}}"

--- a/app/templates/people/index.hbs
+++ b/app/templates/people/index.hbs
@@ -117,7 +117,7 @@
             <p>
               Er werden geen zoekresultaten gevonden. Kijk na op spelfouten, of
               probeer een andere zoekopdracht. Indien een persoon ontbreekt,
-              meldt dit aan
+              meld dit aan
               <a
                 href="mailto:{{config 'contactEmail'}}"
                 class="au-c-link"


### PR DESCRIPTION
OP-3385

Fix typo 'meldt' -> 'meld'