### PR TITLE
fix: corrections to allowed "has a relation with" memberships

### DIFF
--- a/app/constants/memberships.js
+++ b/app/constants/memberships.js
@@ -135,7 +135,6 @@ export const allowedHasRelationWithMemberships = [
     organizations: [...MunicipalityCodeList],
     members: [
       ...OCMWCodeList,
-      ...ProvinceCodeList,
       ...DistrictCodeList,
       ...AgbCodeList,
       ...ApbCodeList,
@@ -154,7 +153,7 @@ export const allowedHasRelationWithMemberships = [
       ...AgbCodeList,
       ...PoliceZoneCodeList,
       ...AssistanceZoneCodeList,
-      ...PevaProvinceCodeList,
+      ...PevaCodeList,
     ],
   },
   {

--- a/tests/unit/models/organization-test.js
+++ b/tests/unit/models/organization-test.js
@@ -14,7 +14,6 @@ import {
   OCMWCodeList,
   PevaCodeList,
   PevaMunicipalityCodeList,
-  PevaProvinceCodeList,
   PoliceZoneCodeList,
   ProvinceCodeList,
   RepresentativeBodyCodeList,
@@ -482,7 +481,7 @@ module('Unit | Model | organization', function (hooks) {
           ...AgbCodeList,
           ...PoliceZoneCodeList,
           ...AssistanceZoneCodeList,
-          ...PevaProvinceCodeList,
+          ...PevaCodeList,
         ],
       ],
       [CLASSIFICATION.AGB, [...MunicipalityCodeList, ...ProvinceCodeList]],
@@ -515,6 +514,11 @@ module('Unit | Model | organization', function (hooks) {
         CLASSIFICATION.REPRESENTATIVE_BODY,
         [...WorshipServiceCodeList, ...CentralWorshipServiceCodeList],
       ],
+      [
+        CLASSIFICATION.PEVA_MUNICIPALITY,
+        [...MunicipalityCodeList, ...ProvinceCodeList],
+      ],
+      [CLASSIFICATION.PEVA_PROVINCE, [...ProvinceCodeList]],
     ].forEach(([cl, classificationCodes]) => {
       test(`it should allow a(n) ${cl.label} to have a relation with the correct organizations`, async function (assert) {
         const classification = this.store().createRecord(


### PR DESCRIPTION
The allowed "has a relation with" memberships contained two errors which are fixed by this PR.

## Removed duplicate allowed membership between municipalities and provinces
Previously it was allowed for municipalities and provinces to be assigned as
either `organization` or `membner` in memberships concerning these two kinds of
organizations. More precisely, memberships with the following assignments were
both allowed:
| organization | member       |
|--------------|--------------|
| municipality | province     |
| province     | municipality |

Only the latter should be allowed. The former was removed as an allowed "has a
relation with" membership.

## Allow provinces to be related with both kinds of PEVAs
Previously a province could only be related to PEVA provinces. This is extended
to also include PEVA municipalities.