### PR TITLE
chore: enable contact data editing in development environment

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -77,7 +77,7 @@ module.exports = function (environment) {
   if (environment === 'development') {
     ENV.showAppVersionHash = true;
     ENV.environmentName = 'development';
-    ENV.features['edit-contact-data'] = 'false';
+    ENV.features['edit-contact-data'] = true;
     // ENV.APP.LOG_RESOLVER = true;
     // ENV.APP.LOG_ACTIVE_GENERATION = true;
     // ENV.APP.LOG_TRANSITIONS = true;


### PR DESCRIPTION
This enables the edit contact data when the frontend is running in a development environment. This is in addition to the environment variable set in https://github.com/lblod/app-organization-portal/pull/457 which only affects the frontend that is part of the stack and not a locally built one.