### PR TITLE
[OP-3384] Fix an issue with the "Type" filter on the organizations page

### DIFF
--- a/app/components/classification-multiple-select.js
+++ b/app/components/classification-multiple-select.js
@@ -80,6 +80,9 @@ export default class ClassificationMultipleSelectComponent extends Component {
     const codes = yield this.store.query('organization-classification-code', {
       'filter[:id:]': allowedIds.join(),
       sort: 'label',
+      page: {
+        size: allowedIds.length,
+      },
     });
 
     // Auto-selects the type if there is only one option

--- a/app/routes/organizations/organization/governing-bodies/governing-body/index.js
+++ b/app/routes/organizations/organization/governing-bodies/governing-body/index.js
@@ -49,7 +49,7 @@ export default class OrganizationsOrganizationGoverningBodiesGoverningBodyIndexR
     // without. This can be removed again once the data is cleaned up.
     memberMandatories = memberMandatories.filter(
       (mandatory, index, memberMandatories) =>
-        index === memberMandatories.findIndex((m) => mandatory.id === m.id)
+        index === memberMandatories.findIndex((m) => mandatory.id === m.id),
     );
 
     let otherMandatories = await this.store.query('mandatory', {
@@ -65,7 +65,7 @@ export default class OrganizationsOrganizationGoverningBodiesGoverningBodyIndexR
     // without. This can be removed again once the data is cleaned up.
     otherMandatories = otherMandatories.filter(
       (mandatory, index, otherMandatories) =>
-        index === otherMandatories.findIndex((m) => mandatory.id === m.id)
+        index === otherMandatories.findIndex((m) => mandatory.id === m.id),
     );
 
     return {


### PR DESCRIPTION
This filter is supposed to show all classification types by default, but due to the default pagination some of the items were missing. This adjusts the page size to the specific amount we need since the total amount of classifications is limited and known in advance.