### PR TITLE
[OP-3486] Enable route splitting

### DIFF
--- a/app/modifiers/yasgui.js
+++ b/app/modifiers/yasgui.js
@@ -1,5 +1,7 @@
 import { modifier } from 'ember-modifier';
 import config from 'frontend-organization-portal/config/environment';
+import Yasgui from '@triply/yasgui';
+import '@triply/yasgui/build/yasgui.min.css';
 
 const defaultQuery =
   config.yasgui.defaultQuery !== '{{YASGUI_DEFAULT_QUERY}}'
@@ -11,17 +13,11 @@ const defaultQuery =
     `;
 
 export default modifier(function yasgui(element /*, params, hash*/) {
-  Promise.all([
-    import('@triply/yasgui'),
-    import('@triply/yasgui/build/yasgui.min.css'),
-  ]).then(([module]) => {
-    const Yasgui = module.default;
-    const yasgui = new Yasgui(element, {
-      requestConfig: { endpoint: '/sparql' },
-      autofocus: true,
-    });
-    yasgui.config.yasqe.value = defaultQuery;
-    if (config.yasgui.extraPrefixes !== '{{YASGUI_EXTRA_PREFIXES}}')
-      yasgui.config.yasqe.addPrefixes(JSON.parse(config.yasgui.extraPrefixes));
+  const yasgui = new Yasgui(element, {
+    requestConfig: { endpoint: '/sparql' },
+    autofocus: true,
   });
+  yasgui.config.yasqe.value = defaultQuery;
+  if (config.yasgui.extraPrefixes !== '{{YASGUI_EXTRA_PREFIXES}}')
+    yasgui.config.yasqe.addPrefixes(JSON.parse(config.yasgui.extraPrefixes));
 });

--- a/app/router.js
+++ b/app/router.js
@@ -1,4 +1,4 @@
-import EmberRouter from '@ember/routing/router';
+import EmberRouter from '@embroider/router';
 import config from 'frontend-organization-portal/config/environment';
 
 export default class Router extends EmberRouter {

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -31,6 +31,7 @@ module.exports = function (defaults) {
         package: 'qunit',
       },
     ],
+    splitAtRoutes: ['mock-login', 'people', 'organizations', 'sparql'],
     packagerOptions: {
       webpackConfig: require('@lblod/ember-rdfa-editor/webpack-config'),
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@embroider/compat": "^3.4.7",
         "@embroider/core": "^3.4.7",
         "@embroider/macros": "^1.16.6",
+        "@embroider/router": "^2.1.8",
         "@embroider/webpack": "^3.2.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
@@ -5976,6 +5977,25 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/@embroider/router": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@embroider/router/-/router-2.1.8.tgz",
+      "integrity": "sha512-Dvp8YdqAWT6T0yzBZfUe6SyaVNH7xoXBlrxF1LbqoF/Q2buNzDy9oAQ5tTnbX1x+5KOrM0ryOjfeF0GoqkfobA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@ember/test-waiters": "^3.0.2",
+        "@embroider/addon-shim": "^1.8.9"
+      },
+      "peerDependencies": {
+        "@embroider/core": "^2.0.0||^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@embroider/core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@embroider/shared-internals": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@embroider/compat": "^3.4.7",
     "@embroider/core": "^3.4.7",
     "@embroider/macros": "^1.16.6",
+    "@embroider/router": "^2.1.8",
     "@embroider/webpack": "^3.2.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",


### PR DESCRIPTION
Embroider makes it possible to enable route splitting which generates bundles for each configured route. Anything that is only used by a single route will be part of a new bundle which gets loaded when the route is first accessed.

Builds on #658 so that needs to be merged first. I've split it off to make it easier to review.

<details>
<summary>Bundle size without route splitting</summary>

```
 - dist/assets/chunk.271abc39a59af301148b.js: 3.04 MB (798.83 kB gzipped)
 - dist/assets/chunk.f659b130de506660e966.js: 1.05 MB (294.22 kB gzipped)
 - dist/assets/chunk.b800ef513827034f4ec9.js: 8.14 kB (2.94 kB gzipped)
 - dist/assets/vendor.72dc14e46dc372212b850c951e74daae.js: 5.66 kB (2.28 kB gzipped)
 - dist/assets/chunk.1c28d157e1a20b2387dd.js: 185 B (149 B gzipped)

 - dist/assets/frontend-organization-portal.1f3a6ca2ecb535a3ef6d1f9b0f882310.css: 164.5 kB (25.05 kB gzipped)
 - dist/assets/chunk.1c28d157e1a20b2387dd.css: 42.68 kB (8.73 kB gzipped)
 ```
</details>

<details>
<summary>Bundle size with route splitting</summary>

```
 - dist/assets/chunk.b1969e18565ccca81f86.js: 1.65 MB (435.17 kB gzipped)
 - dist/assets/chunk.5ee66e8d1e3db1f9a698.js: 1.16 MB (321.1 kB gzipped)
 - dist/assets/chunk.38308a23591ac6c56f77.js: 1.05 MB (295.02 kB gzipped)
 - dist/assets/chunk.5a79aef9dccbec39cdc2.js: 149.28 kB (34.66 kB gzipped)
 - dist/assets/chunk.5a5854d6b6b45ed3006c.js: 73.65 kB (12.84 kB gzipped)
 - dist/assets/chunk.2e77696ece37b7527c54.js: 7.68 kB (2.8 kB gzipped)
 - dist/assets/vendor.72dc14e46dc372212b850c951e74daae.js: 5.66 kB (2.28 kB gzipped)
 - dist/assets/chunk.c24881e7c5dca3e80a38.js: 243 B (154 B gzipped)
 - dist/assets/chunk.ef1eb3b87d0786af69a3.js: 6.64 kB (2.35 kB gzipped)

 - dist/assets/frontend-organization-portal.1f3a6ca2ecb535a3ef6d1f9b0f882310.css: 164.5 kB (25.05 kB gzipped)
 - dist/assets/chunk.38308a23591ac6c56f77.css: 42.68 kB (8.73 kB gzipped)
```
</details>