### PR TITLE
feat: display all resulting organisations for merger change events

### DIFF
--- a/app/routes/organizations/organization/change-events/details.js
+++ b/app/routes/organizations/organization/change-events/details.js
@@ -26,13 +26,6 @@ export default class OrganizationsOrganizationChangeEventsDetailsRoute extends R
       }
     );
 
-    // resolve the first resulting organization here as workaround
-    // the get helper does not work with async relationships in the template
-    // https://github.com/emberjs/ember.js/issues/20510
-    const firstResultingOrganization = (
-      await changeEvent.resultingOrganizations
-    )[0];
-
     let currentChangeEventResult = await findCurrentChangeEventResult(
       organization,
       changeEvent
@@ -42,7 +35,6 @@ export default class OrganizationsOrganizationChangeEventsDetailsRoute extends R
       organization,
       changeEvent,
       currentChangeEventResult,
-      firstResultingOrganization,
     };
   }
 }

--- a/app/templates/organizations/organization/change-events/details/edit.hbs
+++ b/app/templates/organizations/organization/change-events/details/edit.hbs
@@ -159,12 +159,22 @@
             </:left>
             <:right as |Item|>
               {{#if @model.changeEvent.isMergerChangeEvent}}
-                <Item>
-                  <:label>Resulterende organisatie</:label>
-                  <:content>
-                    {{@model.firstResultingOrganization.name}}
-                  </:content>
-                </Item>
+                {{#each
+                  @model.changeEvent.resultingOrganizations
+                  as |organization|
+                }}
+                  <Item>
+                    <:label>Resulterende organisatie</:label>
+                    <:content>
+                      <AuLink
+                        @route="organizations.organization"
+                        @model={{organization.id}}
+                      >
+                        {{organization.name}}
+                      </AuLink>
+                    </:content>
+                  </Item>
+                {{/each}}
                 <Item>
                   <:label>Resulterende status</:label>
                   <:content>

--- a/app/templates/organizations/organization/change-events/details/index.hbs
+++ b/app/templates/organizations/organization/change-events/details/index.hbs
@@ -120,17 +120,22 @@
             </:left>
             <:right as |Item|>
               {{#if @model.changeEvent.isMergerChangeEvent}}
-                <Item>
-                  <:label>Resulterende organisatie</:label>
-                  <:content>
-                    <AuLink
-                      @route="organizations.organization"
-                      @model={{@model.firstResultingOrganization.id}}
-                    >
-                      {{@model.firstResultingOrganization.name}}
-                    </AuLink>
-                  </:content>
-                </Item>
+                {{#each
+                  @model.changeEvent.resultingOrganizations
+                  as |organization|
+                }}
+                  <Item>
+                    <:label>Resulterende organisatie</:label>
+                    <:content>
+                      <AuLink
+                        @route="organizations.organization"
+                        @model={{organization.id}}
+                      >
+                        {{organization.name}}
+                      </AuLink>
+                    </:content>
+                  </Item>
+                {{/each}}
                 <Item>
                   <:label>Resulterende status</:label>
                   <:content>


### PR DESCRIPTION
The 2025 municipality mergers introduce new scenario where a single merger change event has multiple resulting organisations (see backend [PR](https://github.com/lblod/app-organization-portal/pull/482)). Specifically, the municipality Borsbeek and Antwerpen merge, resulting in a new **district** Borsbeek that is part of the Antwerpen municipality.

## Problem
The pages to view and edit the details of a change event only display the first resulting organisation.

## Proposed solution
Make the view and edit change event details display **all** resulting organisations for a change event. The implementation is similar to how original organisations are listed. This change has an additional advantage of simplifying the route's model.

For already existing merger change events with only one resulting organisations, all of them, nothing visually changes.

## Related tickets
- OP-3412