### PR TITLE
[OP-3538]: Revert fixes for positions tables

### DIFF
--- a/app/routes/organizations/organization/governing-bodies/governing-body/index.js
+++ b/app/routes/organizations/organization/governing-bodies/governing-body/index.js
@@ -47,14 +47,10 @@ export default class OrganizationsOrganizationGoverningBodiesGoverningBodyIndexR
     // NOTE (29/10/24): Workaround for the data issue that for some mandatories
     // their name is stored twice, once with a language tag and once
     // without. This can be removed again once the data is cleaned up.
-    const paginationMeta = memberMandatories.meta;
     memberMandatories = memberMandatories.filter(
       (mandatory, index, memberMandatories) =>
         index === memberMandatories.findIndex((m) => mandatory.id === m.id)
     );
-    // We copy over the pagination meta data so pagination links are still displayed.
-    // The numbers won't be 100% correct if any duplicates were removed, but users likely won't notice that.
-    memberMandatories.meta = paginationMeta;
 
     let otherMandatories = await this.store.query('mandatory', {
       ...query,

--- a/app/routes/organizations/organization/governing-bodies/governing-body/index.js
+++ b/app/routes/organizations/organization/governing-bodies/governing-body/index.js
@@ -44,14 +44,6 @@ export default class OrganizationsOrganizationGoverningBodiesGoverningBodyIndexR
       },
     });
 
-    // NOTE (29/10/24): Workaround for the data issue that for some mandatories
-    // their name is stored twice, once with a language tag and once
-    // without. This can be removed again once the data is cleaned up.
-    memberMandatories = memberMandatories.filter(
-      (mandatory, index, memberMandatories) =>
-        index === memberMandatories.findIndex((m) => mandatory.id === m.id)
-    );
-
     let otherMandatories = await this.store.query('mandatory', {
       ...query,
       // mu-cl-resources doesn't support the inverse of `:id:` yet,
@@ -59,14 +51,6 @@ export default class OrganizationsOrganizationGoverningBodiesGoverningBodyIndexR
       // https://github.com/mu-semtech/mu-cl-resources/issues/22
       ['filter[mandate][role-board][:id:]']: MANDATARIES_ROLES.join(),
     });
-
-    // NOTE (29/10/24): Workaround for the data issue that for some mandatories
-    // their name is stored twice, once with a language tag and once
-    // without. This can be removed again once the data is cleaned up.
-    otherMandatories = otherMandatories.filter(
-      (mandatory, index, otherMandatories) =>
-        index === otherMandatories.findIndex((m) => mandatory.id === m.id)
-    );
 
     return {
       organization,


### PR DESCRIPTION
In #656 a workaround was applied to filter the double entries from the several
positions tables for the governing bodies for organisations. This was intended
as a quick fix until the underlying data issues could be solved. But this
workaround broke the table's pagination which was in turn fixed in #663. The
disadvantage is that the numbers displayed underneath the table will no longer
be accurate in case entries were filtered by the first workaround.

After discussing the options with business, it was decided to remove both the
original workaround and the pagination fix that was applied on top of it. A more
permanent fix of the underlying data is underway.

## How to test
1. Launch a local OP stack, the example organisations used below assume you use
   PROD data (note: be sure use the master branch)
2. Launch a frontend for this PR's branch
3. Log in as a worship user
4. Navigate to a worship service that is affected. For example, *Kerkfabriek
   O.-L.-V. van Gedurige Bijstand van Oud-Heverlee (Haasrode)* (uuid:
   `b8c09116f9e603ff109b4f80ba960475`), further examples are in the original
   ticket.
5. Go to the "Bestuursorganen" tab and select the active governing body
6. The tables for "Bestuursleden" and "Mandatarissen" likely contain duplicate
   entries. These may appear/disappear depending on which column you sort
   on. This is the initial bug that was worked around in #656.
7. Log in as non-worship user
8. Navigate to the municipality of Wingene (uuid:
`99ed6eee81a7aca47517cbffb46eaba38f3987eeb4ad32c020898644769eb615`)
9. Go to the "Bestuursorganen" tab and select the active "Gemeenteraad"
10. The "Bestuursleden" table should have 27 entries and functioning pagination

## Notes
- The second commit in #663 adding pagination to "Leidinggevenden" tables is
  kept intact.

## Related tickets
- OP-3538

- OP-3473 concerns the original issue that led to the initial filter workaround
- OP-3536 concerns the broken pagination