### PR TITLE
[OP-3539]: show kbo numbers for organizations in the dropdown

### DIFF
--- a/app/components/organization-select.hbs
+++ b/app/components/organization-select.hbs
@@ -12,8 +12,11 @@
     @selected={{this.selectedOrganization}}
     as |organization|
   >
-    {{organization.abbName}}
-
+    {{#if organization.kboNumber}}
+        {{organization.kboNumber}} - {{organization.abbName}}
+    {{else}}
+        {{organization.abbName}} (geen kbo gevonden)
+    {{/if}}
     {{#if
       (and
         (not

--- a/app/components/organization-select.js
+++ b/app/components/organization-select.js
@@ -78,7 +78,7 @@ export default class OrganizationSelectComponent extends Component {
           },
         },
         sort: 'name',
-        include: 'classification',
+        include: ['classification', 'identifiers.structured-identifier'].join(),
       };
     }
 

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -9,6 +9,7 @@ import {
   validateStringOptional,
 } from '../validators/schema';
 import getOppositeClassifications from '../constants/memberships';
+import { ID_NAME } from './identifier';
 
 export default class OrganizationModel extends AgentModel {
   @attr name;
@@ -127,11 +128,13 @@ export default class OrganizationModel extends AgentModel {
   }
 
   get kboNumber() {
-    const identifiers = this.identifiers.content;
+    const identifiers = this.hasMany('identifiers').value();
 
     for (const identifier of identifiers) {
-      const structuredIdentifier = identifier.get('structuredIdentifier');
-      if (identifier.idName === 'KBO nummer') {
+      const structuredIdentifier = identifier
+        .belongsTo('structuredIdentifier')
+        .value();
+      if (identifier.idName === ID_NAME.KBO) {
         return structuredIdentifier.get('localId');
       }
     }

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -126,6 +126,19 @@ export default class OrganizationModel extends AgentModel {
     });
   }
 
+  get kboNumber() {
+    const identifiers = this.identifiers.content;
+
+    for (const identifier of identifiers) {
+      const structuredIdentifier = identifier.get('structuredIdentifier');
+      if (identifier.idName === 'KBO nummer') {
+        return structuredIdentifier.get('localId');
+      }
+    }
+
+    return null;
+  }
+
   get abbName() {
     return this.legalName ?? this.kboOrganization?.get('name') ?? this.name;
   }


### PR DESCRIPTION
## ID
OP-3539

## Description

Show the KBO number for orgs in the org dropdown (as used in change events).

## How to test

1. Log in as `Josephine WorshipEditeerder`
2. Go to organisaties
3. Select a random org, go to `veranderingsgebeurtenissen` and create a new one
4. Choose `Wijziging gebiedsomgeving` for example
5. At the bottom the field `Betrokken organisatie` will appear, this should now show KBO numbers of the orgs.