### PR TITLE
feat: require confirmation to add a local involvement with an non-active organisation

### DIFF
--- a/app/components/confirm-relation-with-inactive-organization-modal.hbs
+++ b/app/components/confirm-relation-with-inactive-organization-modal.hbs
@@ -1,0 +1,16 @@
+<AuModal @modalOpen={{true}} @closeModal={{@onCancel}}>
+  <:title>Bevestig</:title>
+  <:body>Opgelet, je hebt een niet actieve organisatie geselecteerd. Ben je
+    zeker dat je deze relatie wenst toe te voegen?
+  </:body>
+  <:footer>
+    <AuButtonGroup>
+      <AuButton @alert={{true}} {{on "click" @onConfirm}}>Ja</AuButton>
+      <AuButton
+        @icon="bin"
+        @iconAlignment="left"
+        {{on "click" @onCancel}}
+      >Nee</AuButton>
+    </AuButtonGroup>
+  </:footer>
+</AuModal>{{yield}}

--- a/app/components/organization-select.js
+++ b/app/components/organization-select.js
@@ -78,7 +78,11 @@ export default class OrganizationSelectComponent extends Component {
           },
         },
         sort: 'name',
-        include: ['classification', 'identifiers.structured-identifier'].join(),
+        include: [
+          'classification',
+          'identifiers.structured-identifier',
+          'organization-status',
+        ].join(),
       };
     }
 

--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -1,12 +1,15 @@
 import Controller from '@ember/controller';
 import { action } from '@ember/object';
 import { inject as service } from '@ember/service';
+import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import { INVOLVEMENT_TYPE } from 'frontend-organization-portal/models/involvement-type';
 
 export default class OrganizationsOrganizationLocalInvolvementsEditController extends Controller {
   @service router;
   @service store;
+
+  @tracked nonActiveInvolvedOrganization;
 
   get hasValidationErrors() {
     return (
@@ -48,6 +51,7 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
   @action
   addNewLocalInvolvement() {
     let involvement;
+
     if (this.model.organization.isWorshipService) {
       involvement = this.store.createRecord('local-involvement', {
         organization: this.model.organization,
@@ -62,6 +66,30 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
     }
 
     this.model.involvements.push(involvement);
+  }
+
+  @action
+  setInvolvedOrganization(involvement, organization) {
+    if (organization) {
+      if (organization.isActive) {
+        involvement.administrativeUnit = organization;
+      } else {
+        this.nonActiveInvolvedOrganization = organization;
+      }
+    } else {
+      involvement.administrativeUnit = undefined;
+    }
+  }
+
+  @action
+  confirmSetInvolvedOrganization(involvement) {
+    involvement.administrativeUnit = this.nonActiveInvolvedOrganization;
+    this.nonActiveInvolvedOrganization = undefined;
+  }
+
+  @action
+  cancelSetInvolvedOrganization() {
+    this.nonActiveInvolvedOrganization = undefined;
   }
 
   @action

--- a/app/controllers/organizations/organization/local-involvements/edit.js
+++ b/app/controllers/organizations/organization/local-involvements/edit.js
@@ -88,7 +88,8 @@ export default class OrganizationsOrganizationLocalInvolvementsEditController ex
   }
 
   @action
-  cancelSetInvolvedOrganization() {
+  cancelSetInvolvedOrganization(involvement) {
+    involvement.administrativeUnit = undefined;
     this.nonActiveInvolvedOrganization = undefined;
   }
 

--- a/app/models/organization-status-code.js
+++ b/app/models/organization-status-code.js
@@ -8,4 +8,8 @@ export const ORGANIZATION_STATUS = {
 
 export default class OrganizationStatusCodeModel extends Model {
   @attr label;
+
+  get isActive() {
+    return this.id === ORGANIZATION_STATUS.ACTIVE;
+  }
 }

--- a/app/models/organization.js
+++ b/app/models/organization.js
@@ -170,4 +170,8 @@ export default class OrganizationModel extends AgentModel {
   getClassificationCodesForMembership(membership) {
     return getOppositeClassifications(membership, this);
   }
+
+  get isActive() {
+    return this.belongsTo('organizationStatus').value().isActive;
+  }
 }

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -68,7 +68,7 @@
             }}
               <OrganizationSelect
                 @selected={{involvement.administrativeUnit}}
-                @onChange={{fn (mut involvement.administrativeUnit)}}
+                @onChange={{fn this.setInvolvedOrganization involvement}}
                 @allowClear={{involvement.isNew}}
                 @ariaLabelledBy="organization"
                 @error={{errorMessage}}
@@ -78,8 +78,19 @@
                 {{organization.abbName}}
                 ({{organization.classification.label}})
               </OrganizationSelect>
+
               {{#if errorMessage}}
                 <AuHelpText @error={{true}}>{{errorMessage}}</AuHelpText>
+              {{/if}}
+
+              {{#if this.nonActiveInvolvedOrganization}}
+                <ConfirmRelationWithInactiveOrganizationModal
+                  @onConfirm={{fn
+                    this.confirmSetInvolvedOrganization
+                    involvement
+                  }}
+                  @onCancel={{this.cancelSetInvolvedOrganization}}
+                />
               {{/if}}
             {{/let}}
           </td>

--- a/app/templates/organizations/organization/local-involvements/edit.hbs
+++ b/app/templates/organizations/organization/local-involvements/edit.hbs
@@ -89,7 +89,10 @@
                     this.confirmSetInvolvedOrganization
                     involvement
                   }}
-                  @onCancel={{this.cancelSetInvolvedOrganization}}
+                  @onCancel={{fn
+                    this.cancelSetInvolvedOrganization
+                    involvement
+                  }}
                 />
               {{/if}}
             {{/let}}


### PR DESCRIPTION
This adds functionality to warn a worship user when they add a local involvement with a non-active municipality or province. When a user selects a non-active organisation a popup warns them of this and asks to either explicitly confirm or cancel. Note, in this context "non-active" means any organisation that does not have the status active (*nl. Actief*), currently this means organisations that are inactive (*nl. Niet Actief*) or in formation (*nl. In oprichting*).

When a user selects an active municipality or province the behaviour remains unchanged and no popup should appear.

## How to test
1. Launch a local instance of the backend using https://github.com/lblod/app-organization-portal/pull/519 . Otherwise worship users cannot read the status of a municipality or province and this new functionality will not work.
2. Launch a fronted for this PR: `eds --proxy http://host/` (or however you launch local frontends in you development environment)
3. Log in as `Josephine WorshipEditeerder`
4. Select a (central) worship service, any should do
5. Navigate to the local involvements (*nl. Betrokken lokale besturen*) tab and click the edit button in the top right corner
6. Play around with adding active and non-active local involvement organisations to see the popup appears when expected. Some non-active municipalities are: Galmaarden, Gooik, Herne, and Zwijndrecht. Also try saving and cancelling changes to ensure no errors pop up in this flow.

## Related tickets
- OP-3469