### PR TITLE
[OP-3563] Human readable phone numbers

### DIFF
--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -6,7 +6,6 @@ import { combineFullAddress } from 'frontend-organization-portal/models/address'
 import { action } from '@ember/object';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
 import fetch from 'fetch';
-import { transformPhoneNumbers } from 'frontend-organization-portal/utils/transform-phone-numbers';
 import { CLASSIFICATION } from 'frontend-organization-portal/models/administrative-unit-classification-code';
 import isContactEditableOrganization from 'frontend-organization-portal/utils/editable-contact-data';
 import { MEMBERSHIP_ROLES_MAPPING } from 'frontend-organization-portal/models/membership-role';
@@ -605,13 +604,9 @@ export default class OrganizationsNewController extends Controller {
         isContactEditableOrganization(this.currentOrganizationModel)
       ) {
         contact = setEmptyStringsToNull(contact);
-        contact.telephone = transformPhoneNumbers(contact.telephone);
         yield contact.save();
 
         secondaryContact = setEmptyStringsToNull(secondaryContact);
-        secondaryContact.telephone = transformPhoneNumbers(
-          secondaryContact.telephone,
-        );
         yield secondaryContact.save();
 
         if (!address.isCountryBelgium) {

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -4,7 +4,6 @@ import { inject as service } from '@ember/service';
 import { combineFullAddress } from 'frontend-organization-portal/models/address';
 import { action } from '@ember/object';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
-import { transformPhoneNumbers } from 'frontend-organization-portal/utils/transform-phone-numbers';
 import isContactEditableOrganization from 'frontend-organization-portal/utils/editable-contact-data';
 
 export default class OrganizationsOrganizationCoreDataEditController extends Controller {
@@ -100,7 +99,6 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
         if (contact.hasDirtyAttributes) {
           let isNewContact = contact.isNew;
 
-          contact.telephone = transformPhoneNumbers(contact.telephone);
           contact = setEmptyStringsToNull(contact);
           yield contact.save();
 
@@ -113,9 +111,6 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
         if (secondaryContact.hasDirtyAttributes) {
           let isNewContact = secondaryContact.isNew;
 
-          secondaryContact.telephone = transformPhoneNumbers(
-            secondaryContact.telephone,
-          );
           secondaryContact = setEmptyStringsToNull(secondaryContact);
           yield secondaryContact.save();
 

--- a/app/controllers/organizations/organization/sites/new.js
+++ b/app/controllers/organizations/organization/sites/new.js
@@ -4,7 +4,6 @@ import { dropTask } from 'ember-concurrency';
 import { combineFullAddress } from 'frontend-organization-portal/models/address';
 import { tracked } from '@glimmer/tracking';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
-import { transformPhoneNumbers } from 'frontend-organization-portal/utils/transform-phone-numbers';
 import { action } from '@ember/object';
 
 export default class OrganizationsOrganizationSitesNewController extends Controller {
@@ -34,13 +33,9 @@ export default class OrganizationsOrganizationSitesNewController extends Control
 
     if (!this.hasValidationErrors) {
       contact = setEmptyStringsToNull(contact);
-      contact.telephone = transformPhoneNumbers(contact.telephone);
       yield contact.save();
 
       secondaryContact = setEmptyStringsToNull(secondaryContact);
-      secondaryContact.telephone = transformPhoneNumbers(
-        secondaryContact.telephone,
-      );
       yield secondaryContact.save();
 
       if (!address.isCountryBelgium) {

--- a/app/controllers/organizations/organization/sites/site/edit.js
+++ b/app/controllers/organizations/organization/sites/site/edit.js
@@ -5,7 +5,6 @@ import { tracked } from '@glimmer/tracking';
 import { dropTask } from 'ember-concurrency';
 import { combineFullAddress } from 'frontend-organization-portal/models/address';
 import { setEmptyStringsToNull } from 'frontend-organization-portal/utils/empty-string-to-null';
-import { transformPhoneNumbers } from 'frontend-organization-portal/utils/transform-phone-numbers';
 
 export default class OrganizationsOrganizationSitesSiteEditController extends Controller {
   @service router;
@@ -65,7 +64,6 @@ export default class OrganizationsOrganizationSitesSiteEditController extends Co
       }
 
       if (contact.hasDirtyAttributes) {
-        contact.telephone = transformPhoneNumbers(contact.telephone);
         if (contact.isNew) {
           (yield site.contacts).push(contact);
         }
@@ -75,9 +73,6 @@ export default class OrganizationsOrganizationSitesSiteEditController extends Co
       }
 
       if (secondaryContact.hasDirtyAttributes) {
-        secondaryContact.telephone = transformPhoneNumbers(
-          secondaryContact.telephone,
-        );
         if (secondaryContact.isNew) {
           (yield site.contacts).push(secondaryContact);
         }

--- a/app/helpers/tel-format.js
+++ b/app/helpers/tel-format.js
@@ -2,15 +2,18 @@ import { assert } from '@ember/debug';
 
 const NR_WITH_COUNTRY = /^(?:\+|00)(\d\d)(\d{8,12})$/;
 const NR_WITHOUT_COUNTRY = /^0(\d{8,11})$/;
-const SHORT_NR = /^\d{4}$/;
+const SHORT_NR = /^\d{3,4}$/;
 const FREE_NR = /^0800(\d{4,9})$/;
 const NON_NUMERIC_CHARACTER = /[^\d+]/g;
+const BE_COUNTRY_CODE = '32';
+const singleDigitAreaCodes = ['2', '3', '4', '9'];
 
 /**
- * Formats telephone numbers according to predefined patterns.
+ * Formats telephone numbers according to predefined patterns as documented on the Flemish taaladvies website:
+ * https://www.vlaanderen.be/team-taaladvies/taaladviezen/telefoonnummers-notatie
+ *
  * @param {string} tel - The telephone number to format.
  * @returns {string} Formatted telephone number.
- * @throws {Error} If the input is not a string or does not match any pattern.
  */
 export default function telFormat(tel) {
   assert('expected a single phone number string', arguments.length === 1);
@@ -22,46 +25,114 @@ export default function telFormat(tel) {
     typeof tel === 'string',
   );
 
-  // Remove non-numeric characters from the input
-  const stripped = tel.replace(NON_NUMERIC_CHARACTER, '');
+  assert(
+    'The phone number string should not start with `tel:`. Please provide the raw number instead.',
+    !tel.startsWith('tel:'),
+  );
 
-  // Check if the input matches a short number pattern, return it if it does
-  if (SHORT_NR.test(stripped)) return stripped;
+  const stripped = stripFormatting(tel);
 
-  // Check if the input matches a free number pattern
-  if (FREE_NR.test(stripped)) {
-    // If it does, extract the rest of the number and format it with formatSeriesDigitsFree
-    const match = stripped.match(FREE_NR);
-    const rest = match[1];
-    return `0800 ${formatSeriesDigitsFree(rest)}`;
+  if (isShortNumber(stripped)) {
+    // Short numbers don't require spaces
+    return stripped;
   }
 
-  // If it's not a short number or a free number, determine if it's a number with or without country code
-  try {
-    const { country, rest } = (() => {
-      const match1 = stripped.match(NR_WITH_COUNTRY);
-      if (match1) {
-        return {
-          country: match1[1],
-          rest: match1[2],
-        };
-      }
-      const match2 = stripped.match(NR_WITHOUT_COUNTRY);
-      if (match2) {
-        return {
-          country: '32',
-          rest: match2[1],
-        };
-      }
-      throw new Error('Could not match any telnr regex.');
-    })();
+  if (isSpecialNumber(stripped)) {
+    return formatSpecialNumber(stripped);
+  }
 
-    // Format the number based on whether it has a country code and return it
-    return `+${country} ${formatSeriesDigitsNormal(rest)}`;
-  } catch {
-    // If the phone number doesn't match a pattern we support return it as is so users still see something
+  // At this point we assume we are dealing with regular phone numbers.
+  // For simplicity's sake, we also assume the country code always consists of 2 numbers since that's case for
+  // Belgian phone numbers and our neighboring countries and we don't have to keep a list that way.
+  // When we need to support more we should start looking into libraries to parse the number for us.
+  // Other country codes will still be formatted, but maybe not in the most ideal way.
+
+  if (isRegularPhoneNumber(stripped)) {
+    const normalized = normalizeNumber(stripped);
+    const [, countryCode, digits] = normalized.match(NR_WITH_COUNTRY);
+
+    if (countryCode === BE_COUNTRY_CODE) {
+      let areaCodeLength = 2;
+
+      // The mobile phone check needs to happen first, since 4 is also an area code
+      if (digits.startsWith('4') && digits.length === 9) {
+        areaCodeLength = 3;
+      } else if (singleDigitAreaCodes.includes(digits.at(0))) {
+        areaCodeLength = 1;
+      }
+
+      const areaCode = digits.substring(0, areaCodeLength);
+      const subscriberNumber = digits.substring(areaCodeLength);
+
+      return `+${countryCode} ${areaCode} ${formatSeriesDigitsNormal(subscriberNumber)}`;
+    } else {
+      return `+${countryCode} ${formatSeriesDigitsNormal(digits)}`;
+    }
+  } else {
+    // We do not know what it is, or we don't officially support it yet, so do a best effort at formatting it.
+    return formatSeriesDigitsNormal(stripped);
+  }
+}
+
+/**
+ * Detects if a string is a 3 or 4 digit number (112, 1733, ..)
+ * @param {string} tel
+ * @returns {boolean}
+ */
+function isShortNumber(tel) {
+  return SHORT_NR.test(tel);
+}
+
+/**
+ * Belgium has some special numbers which don't follow the same formatting rules as regular numbers
+ * @param {string} tel
+ * @returns {boolean}
+ */
+function isSpecialNumber(tel) {
+  // TODO: 0800 numbers aren't the only special numbers in Belgium. We can widen our support if needed.
+  // Special number examples: https://nl.wikipedia.org/wiki/Lijst_van_Belgische_zonenummers#Speciale_nummers
+  return FREE_NR.test(tel);
+}
+
+/**
+ * Converts a Belgian national number or 00 prefixed number to the international version
+ * @param {string} tel
+ * @returns {string} normalized number
+ */
+function normalizeNumber(tel) {
+  if (/^\+\d+$/.test(tel)) {
     return tel;
   }
+
+  if (tel.startsWith('00')) {
+    return tel.replace('00', '+');
+  }
+
+  if (tel.startsWith('0')) {
+    return tel.replace('0', '+32');
+  }
+}
+
+function isRegularPhoneNumber(tel) {
+  return isNationalPhoneNumber(tel) || isInternationalPhoneNumber(tel);
+}
+
+function isNationalPhoneNumber(tel) {
+  return NR_WITHOUT_COUNTRY.test(tel);
+}
+
+function isInternationalPhoneNumber(tel) {
+  return NR_WITH_COUNTRY.test(tel);
+}
+
+function stripFormatting(tel) {
+  return tel.replace(NON_NUMERIC_CHARACTER, '');
+}
+
+function formatSpecialNumber(tel) {
+  const match = tel.match(FREE_NR);
+  const rest = match[1];
+  return `0800 ${formatSeriesDigitsFree(rest)}`;
 }
 
 /**

--- a/app/helpers/tel-format.js
+++ b/app/helpers/tel-format.js
@@ -1,8 +1,122 @@
-import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 
-export default helper(function telFormat([tel]) {
-  if (tel.includes('tel:')) {
-    tel = tel.split(':')[1];
+const NR_WITH_COUNTRY = /^(?:\+|00)(\d\d)(\d{8,12})$/;
+const NR_WITHOUT_COUNTRY = /^0(\d{8,11})$/;
+const SHORT_NR = /^\d{4}$/;
+const FREE_NR = /^0800(\d{4,9})$/;
+const NON_NUMERIC_CHARACTER = /[^\d+]/g;
+
+/**
+ * Formats telephone numbers according to predefined patterns.
+ * @param {string} tel - The telephone number to format.
+ * @returns {string} Formatted telephone number.
+ * @throws {Error} If the input is not a string or does not match any pattern.
+ */
+export default function telFormat(tel) {
+  assert('expected a single phone number string', arguments.length === 1);
+
+  if (!tel) return '';
+
+  assert(
+    'The first argument must be a phone number string',
+    typeof tel === 'string',
+  );
+
+  // Remove non-numeric characters from the input
+  const stripped = tel.replace(NON_NUMERIC_CHARACTER, '');
+
+  // Check if the input matches a short number pattern, return it if it does
+  if (SHORT_NR.test(stripped)) return stripped;
+
+  // Check if the input matches a free number pattern
+  if (FREE_NR.test(stripped)) {
+    // If it does, extract the rest of the number and format it with formatSeriesDigitsFree
+    const match = stripped.match(FREE_NR);
+    const rest = match[1];
+    return `0800 ${formatSeriesDigitsFree(rest)}`;
   }
-  return tel;
-});
+
+  // If it's not a short number or a free number, determine if it's a number with or without country code
+  try {
+    const { country, rest } = (() => {
+      const match1 = stripped.match(NR_WITH_COUNTRY);
+      if (match1) {
+        return {
+          country: match1[1],
+          rest: match1[2],
+        };
+      }
+      const match2 = stripped.match(NR_WITHOUT_COUNTRY);
+      if (match2) {
+        return {
+          country: '32',
+          rest: match2[1],
+        };
+      }
+      throw new Error('Could not match any telnr regex.');
+    })();
+
+    // Format the number based on whether it has a country code and return it
+    return `+${country} ${formatSeriesDigitsNormal(rest)}`;
+  } catch {
+    // If the phone number doesn't match a pattern we support return it as is so users still see something
+    return tel;
+  }
+}
+
+/**
+ * Formats a series of digits into groups of two, separated by spaces.
+ * Used for formatting the rest of a free number.
+ * @param {string} digits - A string representing the series of digits.
+ * @returns {string} Formatted string with digits grouped in twos.
+ */
+function formatSeriesDigitsFree(digits) {
+  // Throw an error if there are less than 4 digits
+  if (digits.length < 4)
+    throw new Error('Stopping because of fewer than 4 numbers');
+
+  let input = digits;
+  const output = [];
+
+  // Group the digits in pairs until there are less than 3 remaining
+  while (input.length > 3) {
+    output.push(input.slice(0, 2));
+    input = input.slice(2);
+  }
+  // Push the remaining digits (less than 3) to the output array
+  output.push(input.slice(0));
+
+  return output.join(' ');
+}
+
+/**
+ * Formats a series of digits into groups of two or three, separated by spaces.
+ * Used for formatting the rest of a normal number.
+ * @param {string} digits - A string representing the series of digits.
+ * @returns {string} Formatted string with digits grouped in twos or threes.
+ */
+function formatSeriesDigitsNormal(digits) {
+  // Throw an error if there are less than 4 digits
+  if (digits.length < 4)
+    throw new Error('Stopping because of fewer than 4 numbers');
+
+  let input = digits;
+  const output = [];
+
+  // Take the first chunk of 3 or 2 digits
+  if (digits.length % 2 === 0) {
+    output.push(input.slice(0, 2));
+    input = input.slice(2);
+  } else {
+    output.push(input.slice(0, 3));
+    input = input.slice(3);
+  }
+
+  // Take the remaining digits in chunks of 2
+  while (input.length > 0) {
+    output.push(input.slice(0, 2));
+    input = input.slice(2);
+  }
+
+  return output.join(' ');
+}

--- a/app/models/contact-point.js
+++ b/app/models/contact-point.js
@@ -16,7 +16,7 @@ export const CONTACT_TYPE = {
 
 export default class ContactPointModel extends AbstractValidationModel {
   @attr email;
-  @attr telephone;
+  @attr('phone') telephone;
   @attr fax;
   @attr website;
   @attr type;

--- a/app/utils/transform-phone-numbers.js
+++ b/app/utils/transform-phone-numbers.js
@@ -1,6 +1,0 @@
-export function transformPhoneNumbers(tel) {
-  if (tel) {
-    tel = 'tel:' + tel;
-  }
-  return tel;
-}

--- a/tests/unit/helpers/tel-format-test.js
+++ b/tests/unit/helpers/tel-format-test.js
@@ -1,0 +1,98 @@
+import telFormat from 'frontend-organization-portal/helpers/tel-format';
+import { module, test } from 'qunit';
+
+module('Unit | Helper | tel-format', function () {
+  test('it formats phone numbers into a human readable format', function (assert) {
+    assert.strictEqual(
+      telFormat('+3221524562'),
+      '+32 21 52 45 62',
+      'it supports phone numbers with a + country prefix',
+    );
+    assert.strictEqual(
+      telFormat('+32482455642'),
+      '+32 482 45 56 42',
+      'it supports phone numbers with a + country prefix',
+    );
+    assert.strictEqual(
+      telFormat('003221524562'),
+      '+32 21 52 45 62',
+      'it supports phone numbers with a 00 country prefix',
+    );
+    assert.strictEqual(
+      telFormat('0032482455642'),
+      '+32 482 45 56 42',
+      'it supports phone numbers with a 00 country prefix',
+    );
+    assert.strictEqual(
+      telFormat('021524562'),
+      '+32 21 52 45 62',
+      'it supports phone numbers without a country prefix',
+    );
+    assert.strictEqual(
+      telFormat('0482455642'),
+      '+32 482 45 56 42',
+      'it supports phone numbers without a country prefix',
+    );
+  });
+
+  test('it ignores different formatting patterns', function (assert) {
+    assert.strictEqual(telFormat('021/52.45.62'), '+32 21 52 45 62');
+    assert.strictEqual(telFormat('0482/45 56 42'), '+32 482 45 56 42');
+    assert.strictEqual(telFormat('021 524 562'), '+32 21 52 45 62');
+    assert.strictEqual(telFormat('0 2 1 5 2 4 5 6 2'), '+32 21 52 45 62');
+    assert.strictEqual(telFormat('0482 45 56 42'), '+32 482 45 56 42');
+  });
+
+  test('it supports special phone numbers', function (assert) {
+    assert.strictEqual(
+      telFormat('1733'),
+      '1733',
+      'it supports the special, 4 digit numbers',
+    );
+    assert.strictEqual(
+      telFormat('08001080'),
+      '0800 10 80',
+      'it supports the special 0800 numbers with an even amount of digits',
+    );
+    assert.strictEqual(
+      telFormat('080010800'),
+      '0800 10 800',
+      'it supports the special 0800 numbers with an odd amount of digits',
+    );
+  });
+
+  test('it returns an empty string if a falsy value is provided', function (assert) {
+    assert.strictEqual(telFormat(undefined), '');
+    assert.strictEqual(telFormat(''), '');
+  });
+
+  test('it returns irregular phone numbers unchanged', function (assert) {
+    assert.strictEqual(
+      telFormat('012 345'),
+      '012 345',
+      'it returns irregularly short phone numbers as-is',
+    );
+
+    assert.strictEqual(
+      telFormat('012 345 67 81 23 28'),
+      '012 345 67 81 23 28',
+      'it returns irregularly long phone numbers as-is',
+    );
+  });
+
+  test('it asserts the correct amount of arguments', function (assert) {
+    assert.throws(() => {
+      telFormat();
+    }, /expected a single phone number string/);
+
+    assert.throws(() => {
+      telFormat('1', '2');
+    }, /expected a single phone number string/);
+  });
+
+  test('it asserts the type of the phone number argument', function (assert) {
+    assert.throws(() => {
+      telFormat(1234);
+    }, /The first argument must be a phone number string/);
+  });
+});

--- a/tests/unit/helpers/tel-format-test.js
+++ b/tests/unit/helpers/tel-format-test.js
@@ -2,48 +2,74 @@ import telFormat from 'frontend-organization-portal/helpers/tel-format';
 import { module, test } from 'qunit';
 
 module('Unit | Helper | tel-format', function () {
-  test('it formats phone numbers into a human readable format', function (assert) {
+  test('it supports numbers with a + country prefix', function (assert) {
     assert.strictEqual(
       telFormat('+3221524562'),
-      '+32 21 52 45 62',
-      'it supports phone numbers with a + country prefix',
+      '+32 2 152 45 62',
+      'it supports phone numbers with single digit area code',
+    );
+    assert.strictEqual(
+      telFormat('+3215451825'),
+      '+32 15 45 18 25',
+      'it supports phone numbers with a double digit area code',
     );
     assert.strictEqual(
       telFormat('+32482455642'),
       '+32 482 45 56 42',
-      'it supports phone numbers with a + country prefix',
+      'it supports mobile phone numbers',
     );
+  });
+
+  test('it supports numbers with a 00 country prefix', function (assert) {
     assert.strictEqual(
       telFormat('003221524562'),
-      '+32 21 52 45 62',
-      'it supports phone numbers with a 00 country prefix',
+      '+32 2 152 45 62',
+      'it supports phone numbers with a single digit area code',
+    );
+    assert.strictEqual(
+      telFormat('003215451825'),
+      '+32 15 45 18 25',
+      'it supports phone numbers with a double digit area code',
     );
     assert.strictEqual(
       telFormat('0032482455642'),
       '+32 482 45 56 42',
-      'it supports phone numbers with a 00 country prefix',
+      'it supports mobile phone numbers',
     );
+  });
+
+  test('it supports Belgian national numbers', function (assert) {
     assert.strictEqual(
       telFormat('021524562'),
-      '+32 21 52 45 62',
-      'it supports phone numbers without a country prefix',
+      '+32 2 152 45 62',
+      'it supports phone numbers with a single digit area code',
+    );
+    assert.strictEqual(
+      telFormat('015451825'),
+      '+32 15 45 18 25',
+      'it supports phone numbers with a double digit area code',
     );
     assert.strictEqual(
       telFormat('0482455642'),
       '+32 482 45 56 42',
-      'it supports phone numbers without a country prefix',
+      'it supports mobile phone numbers',
     );
   });
 
-  test('it ignores different formatting patterns', function (assert) {
-    assert.strictEqual(telFormat('021/52.45.62'), '+32 21 52 45 62');
+  test('it ignores existing formatting patterns', function (assert) {
+    assert.strictEqual(telFormat('02/152.45.62'), '+32 2 152 45 62');
     assert.strictEqual(telFormat('0482/45 56 42'), '+32 482 45 56 42');
-    assert.strictEqual(telFormat('021 524 562'), '+32 21 52 45 62');
-    assert.strictEqual(telFormat('0 2 1 5 2 4 5 6 2'), '+32 21 52 45 62');
+    assert.strictEqual(telFormat('021 524 562'), '+32 2 152 45 62');
+    assert.strictEqual(telFormat('0 2 1 5 2 4 5 6 2'), '+32 2 152 45 62');
     assert.strictEqual(telFormat('0482 45 56 42'), '+32 482 45 56 42');
   });
 
   test('it supports special phone numbers', function (assert) {
+    assert.strictEqual(
+      telFormat('112'),
+      '112',
+      'it supports the special, 3 digit numbers',
+    );
     assert.strictEqual(
       telFormat('1733'),
       '1733',
@@ -61,23 +87,24 @@ module('Unit | Helper | tel-format', function () {
     );
   });
 
+  test("it does a best-effort attempt at formatting numbers that we don't explicitly support yet", function (assert) {
+    assert.strictEqual(telFormat('116000'), '11 60 00');
+
+    assert.strictEqual(
+      telFormat('+31201441618'),
+      '+31 201 44 16 18',
+      // 'it formats dutch numbers using general pattern, without special casing the dutch area codes',
+    );
+
+    assert.strictEqual(
+      telFormat('0123456789012345'),
+      '01 23 45 67 89 01 23 45',
+    );
+  });
+
   test('it returns an empty string if a falsy value is provided', function (assert) {
     assert.strictEqual(telFormat(undefined), '');
     assert.strictEqual(telFormat(''), '');
-  });
-
-  test('it returns irregular phone numbers unchanged', function (assert) {
-    assert.strictEqual(
-      telFormat('012 345'),
-      '012 345',
-      'it returns irregularly short phone numbers as-is',
-    );
-
-    assert.strictEqual(
-      telFormat('012 345 67 81 23 28'),
-      '012 345 67 81 23 28',
-      'it returns irregularly long phone numbers as-is',
-    );
   });
 
   test('it asserts the correct amount of arguments', function (assert) {
@@ -94,5 +121,11 @@ module('Unit | Helper | tel-format', function () {
     assert.throws(() => {
       telFormat(1234);
     }, /The first argument must be a phone number string/);
+  });
+
+  test("it asserts that the phone number doesn't contain the `tel:` prefix", function (assert) {
+    assert.throws(() => {
+      telFormat('tel:112');
+    }, /The phone number string should not start with `tel:`. Please provide the raw number instead./);
   });
 });


### PR DESCRIPTION
Based on the [`tel-format` helper](https://github.com/lblod/frontend-contactgegevens-loket/blob/78ab121f0e2807695f01e6edaed6dc23dda3a2fe/app/helpers/tel-format.js) in contactgegevens-loket.