### PR TITLE
[OP-3601] Improve the phone input experience

### DIFF
--- a/app/components/edit-card/item.hbs
+++ b/app/components/edit-card/item.hbs
@@ -11,6 +11,7 @@
         @requiredLabel="*"
         @inline={{true}}
         @error={{@errorMessage}}
+        @warning={{@warningMessage}}
         class={{@labelClass}}
         for={{@labelFor}}
       >
@@ -33,6 +34,8 @@
         {{else}}
           <AuHelpText @error={{true}}>{{@errorMessage}}</AuHelpText>
         {{/if}}
+      {{else if @warningMessage}}
+        <AuHelpText @warning={{true}}>{{@warningMessage}}</AuHelpText>
       {{/if}}
 
       {{#if (has-block "helpText")}}

--- a/app/components/phone-input.hbs
+++ b/app/components/phone-input.hbs
@@ -1,0 +1,11 @@
+{{yield
+  (hash
+    Input=(component
+      "phone-input/input"
+      value=@value
+      warning=this.warningMessage
+      onUpdate=this.onUpdate
+    )
+    warning=this.warningMessage
+  )
+}}

--- a/app/components/phone-input.js
+++ b/app/components/phone-input.js
@@ -1,0 +1,37 @@
+import Component from '@glimmer/component';
+
+const SHORT_BE_NUMBER_LENGTH = 9; // Belgian landline numbers are at least 9 digits long
+const LONG_INTL_NUMBER_LENGTH = 12; // Mobile phone numbers in international notation are 12 characters, including the +
+
+export default class PhoneInput extends Component {
+  get warningMessage() {
+    const phone = this.args.value;
+
+    if (!phone) {
+      return undefined;
+    }
+
+    if (phone.length < SHORT_BE_NUMBER_LENGTH) {
+      return 'Dit telefoonnummer lijkt ongebruikelijk kort. Controleer of het correct is ingevuld.';
+    }
+
+    if (phone.length > LONG_INTL_NUMBER_LENGTH) {
+      return 'Dit telefoonnummer lijkt ongebruikelijk lang. Controleer of het correct is ingevuld.';
+    }
+
+    if (!isInternationalNumber(phone)) {
+      return 'Gebruik bij voorkeur de internationale notatie.';
+    }
+
+    return undefined;
+  }
+
+  onUpdate = (event) => {
+    this.args.onUpdate?.(event.target.value);
+  };
+}
+
+function isInternationalNumber(phone) {
+  const BASIC_INTL_FORMAT_REGEX = /\+\d*/;
+  return BASIC_INTL_FORMAT_REGEX.test(phone);
+}

--- a/app/components/phone-input/input.hbs
+++ b/app/components/phone-input/input.hbs
@@ -1,0 +1,11 @@
+<AuInput
+  @disabled={{@disabled}}
+  @error={{@error}}
+  @warning={{@warning}}
+  @width={{@width}}
+  type="tel"
+  value={{@value}}
+  {{on "focusout" @onUpdate}}
+  {{this.phoneInputMask}}
+  ...attributes
+/>

--- a/app/components/phone-input/input.js
+++ b/app/components/phone-input/input.js
@@ -1,0 +1,18 @@
+import Component from '@glimmer/component';
+import { modifier } from 'ember-modifier';
+import Inputmask from 'inputmask';
+
+const phoneInputMask = modifier(function (element) {
+  new Inputmask({
+    regex: '^\\+?\\d*',
+    placeholder: '',
+  }).mask(element);
+
+  return () => {
+    element.inputmask?.remove();
+  };
+});
+
+export default class Input extends Component {
+  phoneInputMask = phoneInputMask;
+}

--- a/app/components/site/contact-edit-card.hbs
+++ b/app/components/site/contact-edit-card.hbs
@@ -146,47 +146,53 @@
         </AddressSearch>
       </:left>
       <:right as |Item|>
-        <Item
-          @labelFor="site-contact-phone-number"
-          @errorMessage={{@primaryContact.error.telephone.message}}
+        <PhoneInput
+          @value={{@primaryContact.telephone}}
+          @onUpdate={{fn (mut @primaryContact.telephone)}}
+          as |phone|
         >
-          <:label>Primair telefoonnummer</:label>
-          <:content as |hasError|>
-            <TrimInput
-              @width="block"
-              @value={{@primaryContact.telephone}}
-              @onUpdate={{fn (mut @primaryContact.telephone)}}
-              @error={{hasError}}
-              id="site-contact-phone-number"
-              type="tel"
-              {{inputmaskTel}}
-            />
-          </:content>
-          <:helpText>
-            {{help-text "phone-number"}}
-          </:helpText>
-        </Item>
+          <Item
+            @labelFor="site-contact-phone-number"
+            @errorMessage={{@primaryContact.error.telephone.message}}
+            @warningMessage={{phone.warning}}
+          >
+            <:label>Primair telefoonnummer</:label>
+            <:content as |hasError|>
+              <phone.Input
+                @width="block"
+                @error={{hasError}}
+                id="site-contact-phone-number"
+              />
+            </:content>
+            <:helpText>
+              {{help-text "phone-number"}}
+            </:helpText>
+          </Item>
+        </PhoneInput>
 
-        <Item
-          @labelFor="site-contact-secondary-phone-number"
-          @errorMessage={{@secondaryContact.error.telephone.message}}
+        <PhoneInput
+          @value={{@secondaryContact.telephone}}
+          @onUpdate={{fn (mut @secondaryContact.telephone)}}
+          as |phone|
         >
-          <:label>Secundair telefoonnummer</:label>
-          <:content as |hasError|>
-            <TrimInput
-              @width="block"
-              @value={{@secondaryContact.telephone}}
-              @onUpdate={{fn (mut @secondaryContact.telephone)}}
-              @error={{hasError}}
-              id="site-contact-secondary-phone-number"
-              type="tel"
-               {{inputmaskTel}}
-            />
-          </:content>
-          <:helpText>
-            {{help-text "phone-number"}}
-          </:helpText>
-        </Item>
+          <Item
+            @labelFor="site-contact-secondary-phone-number"
+            @errorMessage={{@secondaryContact.error.telephone.message}}
+            @warningMessage={{phone.warning}}
+          >
+            <:label>Secundair telefoonnummer</:label>
+            <:content as |hasError|>
+              <phone.Input
+                @width="block"
+                @error={{hasError}}
+                id="site-contact-secondary-phone-number"
+              />
+            </:content>
+            <:helpText>
+              {{help-text "phone-number"}}
+            </:helpText>
+          </Item>
+        </PhoneInput>
         <Item
           @labelFor="site-contact-email"
           @errorMessage={{@primaryContact.error.email.message}}

--- a/app/modifiers/inputmaskTel.js
+++ b/app/modifiers/inputmaskTel.js
@@ -1,8 +1,0 @@
-import { modifier } from 'ember-modifier';
-import Inputmask from 'inputmask';
-
-export default modifier(function inputmaskTel(element) {
-  new Inputmask({
-    regex: '(\\+)\\d{10}\\d*',
-  }).mask(element);
-});


### PR DESCRIPTION
- Allow entry of phone numbers without a `+`, so special numbers can be entered
- display warnings when users enter unusually short, unusually long or numbers not in the international notation.