### PR TITLE
Handle addresses outside flanders better

### DIFF
--- a/app/components/site/contact-edit-card.hbs
+++ b/app/components/site/contact-edit-card.hbs
@@ -87,7 +87,7 @@
                 />
               </:content>
             </Item>
-            {{#if @address.isCountryBelgium}}
+            {{#if @address.isPostcodeInFlanders}}
               <Item
                 @labelFor="site-address-municipality"
                 @required={{true}}
@@ -124,7 +124,7 @@
             {{/if}}
           </:manualAddressInput>
           <:commonInput>
-            {{#if (and @address.isCountryBelgium @address.isPostcodeInFlanders)}}
+            {{#if @address.isPostcodeInFlanders}}
               <Item
                 @labelFor="site-address-province"
                 @required={{true}}

--- a/app/components/site/contact-edit-card.hbs
+++ b/app/components/site/contact-edit-card.hbs
@@ -81,7 +81,7 @@
                 <TrimInput
                   @width="block"
                   @value={{@address.postcode}}
-                  @onUpdate={{fn (mut @address.postcode)}}
+                  @onUpdate={{this.updatePostCode}}
                   @error={{hasError}}
                   id="site-address-postal-code"
                 />
@@ -124,7 +124,7 @@
             {{/if}}
           </:manualAddressInput>
           <:commonInput>
-            {{#if @address.isCountryBelgium}}
+            {{#if (and @address.isCountryBelgium @address.isPostcodeInFlanders)}}
               <Item
                 @labelFor="site-address-province"
                 @required={{true}}

--- a/app/components/site/contact-edit-card.js
+++ b/app/components/site/contact-edit-card.js
@@ -8,4 +8,11 @@ export default class ContactEditCard extends Component {
     this.args.address.municipality = null;
     this.args.address.province = null;
   }
+
+  @action
+  updatePostCode(value) {
+    this.args.address.postcode = value;
+    this.args.address.municipality = null;
+    this.args.address.province = null;
+  }
 }

--- a/app/controllers/organizations/new.js
+++ b/app/controllers/organizations/new.js
@@ -617,7 +617,7 @@ export default class OrganizationsNewController extends Controller {
         secondaryContact = setEmptyStringsToNull(secondaryContact);
         yield secondaryContact.save();
 
-        if (!address.isCountryBelgium) {
+        if (!address.isPostcodeInFlanders) {
           address.province = '';
         }
 

--- a/app/controllers/organizations/organization/core-data/edit.js
+++ b/app/controllers/organizations/organization/core-data/edit.js
@@ -101,7 +101,7 @@ export default class OrganizationsOrganizationCoreDataEditController extends Con
         }
 
         if (address.hasDirtyAttributes) {
-          if (!address.isCountryBelgium) {
+          if (!address.isPostcodeInFlanders) {
             address.province = '';
           }
           address.fullAddress = combineFullAddress(address);

--- a/app/controllers/organizations/organization/sites/new.js
+++ b/app/controllers/organizations/organization/sites/new.js
@@ -38,7 +38,7 @@ export default class OrganizationsOrganizationSitesNewController extends Control
       secondaryContact = setEmptyStringsToNull(secondaryContact);
       yield secondaryContact.save();
 
-      if (!address.isCountryBelgium) {
+      if (!address.isPostcodeInFlanders) {
         address.province = '';
       }
 

--- a/app/controllers/organizations/organization/sites/site/edit.js
+++ b/app/controllers/organizations/organization/sites/site/edit.js
@@ -54,7 +54,7 @@ export default class OrganizationsOrganizationSitesSiteEditController extends Co
 
     if (!this.hasValidationErrors) {
       if (address.hasDirtyAttributes) {
-        if (!address.isCountryBelgium) {
+        if (!address.isPostcodeInFlanders) {
           address.province = '';
         }
         address.fullAddress = combineFullAddress(address);

--- a/app/models/address.js
+++ b/app/models/address.js
@@ -38,7 +38,7 @@ export default class AddressModel extends AbstractValidationModel {
 
   get validationSchema() {
     const REQUIRED_MESSAGE = 'Vul het volledige adres in';
-    const schema = Joi.object({
+    return Joi.object({
       street: Joi.string()
         .empty('')
         .required()
@@ -76,8 +76,6 @@ export default class AddressModel extends AbstractValidationModel {
       addressRegisterUri: validateStringOptional(),
       source: validateBelongsToOptional(),
     });
-
-    return schema;
   }
 }
 

--- a/app/models/address.js
+++ b/app/models/address.js
@@ -30,7 +30,10 @@ export default class AddressModel extends AbstractValidationModel {
   }
 
   get isPostcodeInFlanders() {
-    return (this.postcode >= 1500 && this.postcode <= 3999) || (this.postcode >= 8000 && this.postcode <= 9999);
+    return (
+      (this.postcode >= 1500 && this.postcode <= 3999) ||
+      (this.postcode >= 8000 && this.postcode <= 9999)
+    );
   }
 
   get validationSchema() {
@@ -56,17 +59,18 @@ export default class AddressModel extends AbstractValidationModel {
         .empty('')
         .required()
         .messages({ '*': REQUIRED_MESSAGE }),
-      province: Joi.string().empty('').allow(null).external(async (value, helpers) => {
-        if (this.isCountryBelgium && this.isPostcodeInFlanders) {
-          if (!value) {
-            return helpers.message(
-              REQUIRED_MESSAGE
-            );
+      province: Joi.string()
+        .empty('')
+        .allow(null)
+        .external(async (value, helpers) => {
+          if (this.isCountryBelgium && this.isPostcodeInFlanders) {
+            if (!value) {
+              return helpers.message(REQUIRED_MESSAGE);
+            }
           }
-        }
 
-        return value;
-      }),
+          return value;
+        }),
       boxNumber: validateStringOptional(),
       fullAddress: validateStringOptional(),
       addressRegisterUri: validateStringOptional(),

--- a/app/models/address.js
+++ b/app/models/address.js
@@ -30,10 +30,12 @@ export default class AddressModel extends AbstractValidationModel {
   }
 
   get isPostcodeInFlanders() {
-    return (
+    const isPostcodeFourDigits = this.postcode.match(/^\d{4}$/);
+    const isPostcodeWithinFlanders =
       (this.postcode >= 1500 && this.postcode <= 3999) ||
-      (this.postcode >= 8000 && this.postcode <= 9999)
-    );
+      (this.postcode >= 8000 && this.postcode <= 9999);
+
+    return isPostcodeFourDigits && isPostcodeWithinFlanders;
   }
 
   get validationSchema() {

--- a/app/models/address.js
+++ b/app/models/address.js
@@ -30,12 +30,19 @@ export default class AddressModel extends AbstractValidationModel {
   }
 
   get isPostcodeInFlanders() {
-    const isPostcodeFourDigits = this.postcode.match(/^\d{4}$/);
-    const isPostcodeWithinFlanders =
-      (this.postcode >= 1500 && this.postcode <= 3999) ||
-      (this.postcode >= 8000 && this.postcode <= 9999);
+    if (this.country && this.postcode) {
+      const isPostcodeFourDigits = this.postcode.match(/^\d{4}$/);
+      const isPostcodeWithinFlanders =
+        (this.postcode >= 1500 && this.postcode <= 3999) ||
+        (this.postcode >= 8000 && this.postcode <= 9999);
 
-    return isPostcodeFourDigits && isPostcodeWithinFlanders;
+      return (
+        this.isCountryBelgium &&
+        isPostcodeFourDigits &&
+        isPostcodeWithinFlanders
+      );
+    }
+    return false;
   }
 
   get validationSchema() {
@@ -65,7 +72,7 @@ export default class AddressModel extends AbstractValidationModel {
         .empty('')
         .allow(null)
         .external(async (value, helpers) => {
-          if (this.isCountryBelgium && this.isPostcodeInFlanders) {
+          if (this.isPostcodeInFlanders) {
             if (!value) {
               return helpers.message(REQUIRED_MESSAGE);
             }

--- a/app/routes/organizations/organization/core-data/index.js
+++ b/app/routes/organizations/organization/core-data/index.js
@@ -68,6 +68,7 @@ export default class OrganizationsOrganizationCoreDataIndexRoute extends Route {
           scope = await municipalityUnit.scope;
         }
       }
+
       const containingLocations = await scope.locatedWithin;
       // NOTE (03/06/2025): This relies on the fact that reference regions do
       // *not* overlap. In other words, an organisation cannot be located in


### PR DESCRIPTION
# Context

[OP-3638]

The decision taken to handle provinces for addresses outside of Flanders states that:
- we shouldn't link a province to addresses outside of Flanders
- we should be able to manually enter addresses outside of Flanders (and even outside of Belgium)
- a province is still mandatory for addresses within Flanders

This PR aims to update the validations for provinces to make it mandatory only when the address is in Flanders.

# How to test?

Create a new site and try different options: other country, Belgium, postcode in Flanders, outside of Flanders, to see if the province is made mandatory or not by the validation rules. It should only be mandatory within Flanders. The filed should be hidden in all the other cases, and the province shouldn't be required to be able to save the site.