### PR TITLE
[OP-3655] don't clear the address when postcode value is unchanged

### DIFF
--- a/app/components/site/contact-edit-card.js
+++ b/app/components/site/contact-edit-card.js
@@ -11,6 +11,8 @@ export default class ContactEditCard extends Component {
 
   @action
   updatePostCode(value) {
+    if (this.args.address.postcode === value) return;
+
     this.args.address.postcode = value;
     this.args.address.municipality = null;
     this.args.address.province = null;

--- a/app/components/site/contact-edit-card.js
+++ b/app/components/site/contact-edit-card.js
@@ -11,8 +11,6 @@ export default class ContactEditCard extends Component {
 
   @action
   updatePostCode(value) {
-    if (this.args.address.postcode === value) return;
-
     this.args.address.postcode = value;
     this.args.address.municipality = null;
     this.args.address.province = null;

--- a/app/components/trim-input.js
+++ b/app/components/trim-input.js
@@ -4,7 +4,7 @@ import { restartableTask } from 'ember-concurrency';
 export default class TrimInputComponent extends Component {
   @restartableTask
   *trimInput(event) {
-    const input = yield event.target.value;
-    if (this.args.value !== input) this.args.onUpdate(input.trim());
+    const input = (yield event.target.value).trim();
+    if (this.args.value !== input) this.args.onUpdate(input);
   }
 }

--- a/app/components/trim-input.js
+++ b/app/components/trim-input.js
@@ -5,6 +5,6 @@ export default class TrimInputComponent extends Component {
   @restartableTask
   *trimInput(event) {
     const input = yield event.target.value;
-    this.args.onUpdate(input.trim());
+    if (this.args.value !== input) this.args.onUpdate(input.trim());
   }
 }


### PR DESCRIPTION
## ID

OP-3655

## Description

When tabbing through the contact edit card, an unchanged postal code will still trigger the clearing of municipality and province, even if it's not changed. So added a small check.

Since the postcode is inside a `TrimInput` component, this seemed like the easiest option to fix the bug since the `{{on "focusout" (perform this.trimInput)}}` will get triggered.